### PR TITLE
Switch MCP mount to streamable HTTP and bump version to 0.9.34

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytincture"
-version = "0.9.33"
+version = "0.9.34"
 description = "UI Builder"
 readme = "README.md"
 license = { text = "MIT" }

--- a/pytincture/__init__.py
+++ b/pytincture/__init__.py
@@ -2,7 +2,7 @@
 pyTincture uvicorn launcher
 """
 
-__version__ = "0.9.33"
+__version__ = "0.9.34"
 
 from multiprocessing import Process, freeze_support
 import os

--- a/pytincture/backend/app.py
+++ b/pytincture/backend/app.py
@@ -60,6 +60,18 @@ from html import escape
 app = FastAPI(title="pyTincture API")
 
 
+def _build_streamable_mcp_app(mcp_server, path: str = "/"):
+    http_builder = getattr(mcp_server, "http_app", None)
+    if callable(http_builder):
+        return http_builder(path=path, transport="streamable-http")
+
+    streamable_builder = getattr(mcp_server, "streamable_http_app", None)
+    if callable(streamable_builder):
+        return streamable_builder(path=path)
+
+    raise AttributeError("FastMCP server does not expose streamable_http_app() or http_app()")
+
+
 def _build_dynamic_module_name(file_path: str, name_hint: str) -> str:
     """
     Build a stable module name for manually loaded source files.
@@ -110,13 +122,13 @@ def _load_source_module(file_path: str, name_hint: str):
     return module
 
 def reload_mcp_tools():
-    global mcp, sse_mcp_app  # Use globals or pass as needed if in a class/module
+    global mcp, mcp_http_app  # Use globals or pass as needed if in a class/module
     
     # Step 1: Remove existing MCP-mounted routes to avoid duplicates
-    # Filter out routes starting with "/sse-mcp" (adjust prefix if needed)
+    # Filter out routes starting with "/mcp" to avoid duplicate mounts.
     app.router.routes = [
         route for route in app.router.routes
-        if not route.path.startswith("/sse-mcp")
+        if not route.path.startswith("/mcp")
     ]
     
     # Step 2: Recreate FastMCP instance (rescans app for new endpoints/tools)
@@ -140,11 +152,11 @@ def reload_mcp_tools():
             if name_length > 64:
                 print(f"  WARNING: Exceeds 64-char limit! Suggested truncate: {tool.name[:61]}...")
     
-    # Step 3: Recreate SSE app
-    sse_mcp_app = mcp.sse_app(path='/')
+    # Step 3: Recreate MCP app using streamable HTTP transport
+    mcp_http_app = _build_streamable_mcp_app(mcp, path='/')
     
-    # Step 4: Remount the updated SSE app
-    app.mount("/sse-mcp", sse_mcp_app)
+    # Step 4: Remount the updated MCP app
+    app.mount("/mcp", mcp_http_app)
 
 def create_appcode_pkg_in_memory(host, protocol):
     """Generate an appcode package in memory for the browser to pull for the frontend."""

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -12,6 +12,7 @@ from fastapi.testclient import TestClient
 from pytincture.backend.app import (
     app,
     ALLOWED_NOAUTH_CLASSCALLS,
+    _build_streamable_mcp_app,
     _build_dynamic_module_name,
     _sanitize_return_to,
     set_bff_policy_hook,
@@ -105,6 +106,29 @@ def test_main_route_no_auth_when_disabled(fresh_client, monkeypatch):
     application_name = "demoapp"
     response = fresh_client.get(f"/{application_name}")
     assert response.status_code == 200
+
+
+def test_build_streamable_mcp_app_prefers_http_app():
+    class DummyMCP:
+        def streamable_http_app(self, path=None):
+            return {"transport": "streamable_http_app", "path": path}
+
+        def http_app(self, path=None, transport=None):
+            return {"transport": transport, "path": path}
+
+    result = _build_streamable_mcp_app(DummyMCP(), path="/")
+
+    assert result == {"transport": "streamable-http", "path": "/"}
+
+
+def test_build_streamable_mcp_app_falls_back_to_http_app():
+    class DummyMCP:
+        def http_app(self, path=None, transport=None):
+            return {"transport": transport, "path": path}
+
+    result = _build_streamable_mcp_app(DummyMCP(), path="/")
+
+    assert result == {"transport": "streamable-http", "path": "/"}
 
 def test_class_call_noauth(dummy_module, monkeypatch, fresh_client):
     """


### PR DESCRIPTION
Update the FastMCP integration to mount the server at /mcp using streamable HTTP instead of the old SSE-based endpoint. This keeps MCP setup compatible with newer FastMCP releases that no longer expose the previous SSE interface while preserving automatic remount behavior and adding focused coverage for the transport builder.