### PR TITLE
Add Microsoft OAuth and silence auth debug logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ pip install .
    example: "some@email.com,joe@email.com"
 - ENABLE_GOOGLE_AUTH: Enable the respective authentication mechanisms.
    example: "true"
+- ENABLE_MICROSOFT_AUTH: Enable Microsoft OAuth2 authentication using the shared `common` tenant endpoint.
+   example: "true"
+- GOOGLE_CLIENT_ID: OAuth client ID for Google.
+- GOOGLE_CLIENT_SECRET: OAuth client secret for Google.
+- MICROSOFT_CLIENT_ID: OAuth client ID for Microsoft Azure AD / Microsoft identity platform.
+- MICROSOFT_CLIENT_SECRET: OAuth client secret for Microsoft Azure AD / Microsoft identity platform.
 - ENABLE_SAML_AUTH: Enable SAML 2.0 authentication.
    example: "true"
 - SAML_EMAIL_ATTRIBUTE: Attribute name used to extract the user email from the SAML assertion.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytincture"
-version = "0.9.36"
+version = "0.9.37"
 description = "UI Builder"
 readme = "README.md"
 license = { text = "MIT" }

--- a/pytincture/__init__.py
+++ b/pytincture/__init__.py
@@ -2,7 +2,7 @@
 pyTincture uvicorn launcher
 """
 
-__version__ = "0.9.36"
+__version__ = "0.9.37"
 
 from multiprocessing import Process, freeze_support
 import os

--- a/pytincture/backend/app.py
+++ b/pytincture/backend/app.py
@@ -547,23 +547,18 @@ def require_auth(request: Request):
     if ENABLE_GOOGLE_AUTH or ENABLE_USER_LOGIN or ENABLE_SAML_AUTH:
         user_session = request.session.get("user") or {}
         email = user_session.get("email")
-        print(f"DEBUG AUTH: session email={email} keys={list(request.session.keys())}")
         if not email:
-            print("DEBUG AUTH: no email found in session")
             return None
 
         backend_snapshot = USER_SESSION_DICT.get(email)
         if backend_snapshot is None:
-            print("DEBUG AUTH: email missing from USER_SESSION_DICT, seeding from session")
             USER_SESSION_DICT[email] = user_session
             return user_session
 
         if user_session != backend_snapshot:
-            print("DEBUG AUTH: session and backend snapshots differ")
             _clear_auth_session(request)
             raise HTTPException(status_code=401, detail="Error with authentication")
 
-        print("DEBUG AUTH: session validated via USER_SESSION_DICT")
         return user_session
     else:
         return {
@@ -765,10 +760,13 @@ async def logs_endpoint(request: Request, user=Depends(require_auth)):
 ENABLE_GOOGLE_AUTH = os.getenv("ENABLE_GOOGLE_AUTH", "false").lower() == "true"
 ENABLE_USER_LOGIN = os.getenv("ENABLE_USER_LOGIN", "false").lower() == "true"
 ENABLE_SAML_AUTH = os.getenv("ENABLE_SAML_AUTH", "false").lower() == "true"
+ENABLE_MICROSOFT_AUTH = os.getenv("ENABLE_MICROSOFT_AUTH", "false").lower() == "true"
 
 config_data = {
     "GOOGLE_CLIENT_ID": os.getenv("GOOGLE_CLIENT_ID", ""),
     "GOOGLE_CLIENT_SECRET": os.getenv("GOOGLE_CLIENT_SECRET", ""),
+    "MICROSOFT_CLIENT_ID": os.getenv("MICROSOFT_CLIENT_ID", ""),
+    "MICROSOFT_CLIENT_SECRET": os.getenv("MICROSOFT_CLIENT_SECRET", ""),
     "SECRET_KEY": os.getenv("SECRET_KEY", "verysecretkey"),
 }
 config = Config(environ=config_data)
@@ -1274,17 +1272,26 @@ def _sanitize_return_to(value: Optional[str]) -> Optional[str]:
         sanitized += f"#{parsed.fragment}"
     return sanitized
 
-# Create an OAuth object and register the Google provider
-if ENABLE_GOOGLE_AUTH:
+# Create an OAuth object and register supported providers
+if ENABLE_GOOGLE_AUTH or ENABLE_MICROSOFT_AUTH:
     oauth = OAuth(config)
-    oauth.register(
-        name="google",
-        client_id=config.get("GOOGLE_CLIENT_ID"),
-        client_secret=config.get("GOOGLE_CLIENT_SECRET"),
-        # Use the well-known OIDC discovery document
-        server_metadata_url="https://accounts.google.com/.well-known/openid-configuration",
-        client_kwargs={"scope": "openid email profile"},
-    )
+    if ENABLE_GOOGLE_AUTH:
+        oauth.register(
+            name="google",
+            client_id=config.get("GOOGLE_CLIENT_ID"),
+            client_secret=config.get("GOOGLE_CLIENT_SECRET"),
+            # Use the well-known OIDC discovery document
+            server_metadata_url="https://accounts.google.com/.well-known/openid-configuration",
+            client_kwargs={"scope": "openid email profile"},
+        )
+    if ENABLE_MICROSOFT_AUTH:
+        oauth.register(
+            name="microsoft",
+            client_id=config.get("MICROSOFT_CLIENT_ID"),
+            client_secret=config.get("MICROSOFT_CLIENT_SECRET"),
+            server_metadata_url="https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration",
+            client_kwargs={"scope": "openid email profile offline_access"},
+        )
 else:
     oauth = None
 
@@ -1721,7 +1728,12 @@ async def auth_google_callback(request: Request, application: str):
     except OAuthError as e:
         return JSONResponse({"error": str(e)}, status_code=401)
     
-    user_info = token.get("userinfo")
+    user_info = token.get("userinfo") or {}
+    if not user_info:
+        try:
+            user_info = await oauth.google.parse_id_token(request, token)
+        except Exception:
+            user_info = user_info or {}
 
     # You can optionally grab user info from token["userinfo"]
     if os.getenv("ALLOWED_EMAILS", "") != "":
@@ -1733,6 +1745,53 @@ async def auth_google_callback(request: Request, application: str):
     request.session["user"] = user_info  # store in session
 
     # See if we stored a "return_to" path earlier; default to "/"
+    return_to = _sanitize_return_to(request.session.pop("return_to", None)) or "/"
+    return RedirectResponse(url=return_to)
+
+@app.get("/{application}/auth/microsoft", operation_id="initiateMicrosoftAuth", response_class=RedirectResponse, responses={302: {"description": "RedirectResponse (to Microsoft OAuth URL)"}})
+async def auth_microsoft(request: Request, application: str):
+    """
+    Redirect the user to Microsoft's OAuth2 screen.
+    """
+    if oauth is None or not ENABLE_MICROSOFT_AUTH:
+        raise HTTPException(status_code=404, detail="Microsoft authentication not enabled")
+
+    forwarded_proto = request.headers.get("x-forwarded-proto")
+    host = request.headers["host"]
+    protocol = forwarded_proto or request.url.scheme
+    redirect_uri = f"{protocol}://{host}/{application}/auth/microsoft/callback"
+
+    return await oauth.microsoft.authorize_redirect(request, redirect_uri)
+
+@app.get("/{application}/auth/microsoft/callback", name="auth_microsoft_callback", operation_id="handleMicrosoftAuthCallback", response_class=RedirectResponse, responses={302: {"description": "RedirectResponse (to original path after login)"}, 401: {"description": "JSONResponse (if OAuth error or not authorized)"}})
+async def auth_microsoft_callback(request: Request, application: str):
+    """
+    Microsoft redirects here after login. Authlib will exchange code for token.
+    We'll store user info in the session, then redirect back to original app path.
+    """
+    if oauth is None or not ENABLE_MICROSOFT_AUTH:
+        raise HTTPException(status_code=404, detail="Microsoft authentication not enabled")
+
+    try:
+        token = await oauth.microsoft.authorize_access_token(request)
+    except OAuthError as e:
+        return JSONResponse({"error": str(e)}, status_code=401)
+
+    user_info = token.get("userinfo") or {}
+    if not user_info:
+        try:
+            user_info = await oauth.microsoft.parse_id_token(request, token)
+        except Exception:
+            user_info = user_info or {}
+
+    if os.getenv("ALLOWED_EMAILS", "") != "":
+        allowed_emails = os.getenv("ALLOWED_EMAILS").split(",")  # Assuming comma-separated
+        if user_info.get("email", "").lower() not in [email.strip().lower() for email in allowed_emails]:
+            return JSONResponse({"error": "Not authorized"}, status_code=401)
+
+    USER_SESSION_DICT[user_info["email"]] = user_info
+    request.session["user"] = user_info  # store in session
+
     return_to = _sanitize_return_to(request.session.pop("return_to", None)) or "/"
     return RedirectResponse(url=return_to)
 
@@ -1767,9 +1826,10 @@ async def login(request: Request, application: str):
     enable_google_auth = _resolve_auth_flag("ENABLE_GOOGLE_AUTH", ENABLE_GOOGLE_AUTH)
     enable_user_login = _resolve_auth_flag("ENABLE_USER_LOGIN", ENABLE_USER_LOGIN)
     enable_saml_auth = _resolve_auth_flag("ENABLE_SAML_AUTH", ENABLE_SAML_AUTH)
+    enable_microsoft_auth = _resolve_auth_flag("ENABLE_MICROSOFT_AUTH", ENABLE_MICROSOFT_AUTH)
 
     saml_login_buttons = _get_saml_login_buttons() if enable_saml_auth else []
-    if enable_saml_auth and not enable_google_auth and not enable_user_login and len(saml_login_buttons) == 1:
+    if enable_saml_auth and not enable_google_auth and not enable_user_login and not enable_microsoft_auth and len(saml_login_buttons) == 1:
         return RedirectResponse(url=f"/{application}/{saml_login_buttons[0]['href']}", status_code=302)
 
     # Start building the HTML content
@@ -1871,6 +1931,11 @@ async def login(request: Request, application: str):
             '<a href="auth/google" class="login-button">Login with Google</a>'
         )
 
+    if enable_microsoft_auth:
+        social_buttons.append(
+            '<a href="auth/microsoft" class="login-button">Login with Microsoft</a>'
+        )
+
     if enable_saml_auth:
         for button in saml_login_buttons:
             label = escape(button["label"])
@@ -1902,7 +1967,7 @@ async def login(request: Request, application: str):
         '''
 
     # Handle case where no login methods are enabled
-    if not (enable_google_auth or enable_user_login or enable_saml_auth):
+    if not (enable_google_auth or enable_user_login or enable_saml_auth or enable_microsoft_auth):
         html_content += '''
             <p>No login methods are currently available. Please contact support.</p>
         '''

--- a/pytincture/frontend/package.json
+++ b/pytincture/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pytincture/runtime",
-  "version": "0.9.36",
+  "version": "0.9.37",
   "description": "Standalone pytincture.js runtime with inline app auto-start support.",
   "type": "module",
   "main": "dist/pytincture.js",

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -561,6 +561,23 @@ def test_logs_endpoint(fresh_client, monkeypatch):
     data = response.json()
     assert data.get("status") == "ok"
 
+
+def test_require_auth_does_not_print_debug_output(monkeypatch, capsys):
+    """Successful session validation should not write authentication details to stdout."""
+    import pytincture.backend.app as backend_app
+
+    user = {"email": "quiet@example.com"}
+    request = type("Request", (), {"session": {"user": user}})()
+
+    monkeypatch.setattr(backend_app, "ENABLE_GOOGLE_AUTH", True)
+    monkeypatch.setattr(backend_app, "ENABLE_USER_LOGIN", False)
+    monkeypatch.setattr(backend_app, "ENABLE_SAML_AUTH", False)
+    monkeypatch.setattr(backend_app, "USER_SESSION_DICT", {user["email"]: user})
+
+    assert backend_app.require_auth(request) == user
+    assert capsys.readouterr().out == ""
+
+
 def test_login_endpoint(fresh_client, monkeypatch, tmp_path):
     """
     Test the /{application}/login endpoint returns expected HTML content.
@@ -581,6 +598,29 @@ def test_login_endpoint(fresh_client, monkeypatch, tmp_path):
     assert "Login with Google" in html
     assert "type=\"email\"" in html
     assert "type=\"password\"" in html
+
+
+def test_login_endpoint_includes_microsoft_button_when_enabled(fresh_client, monkeypatch, tmp_path):
+    """
+    Ensure the login page surfaces the Microsoft option when it is enabled.
+    """
+    import pytincture.backend.app as backend_app
+
+    dummy_frontend = tmp_path / "frontend"
+    dummy_frontend.mkdir()
+    (dummy_frontend / "index.html").write_text("<html>***APPLICATION***</html>")
+
+    monkeypatch.setattr(backend_app, "STATIC_PATH", str(dummy_frontend))
+    monkeypatch.setattr(backend_app, "ENABLE_GOOGLE_AUTH", False)
+    monkeypatch.setattr(backend_app, "ENABLE_USER_LOGIN", False)
+    monkeypatch.setattr(backend_app, "ENABLE_SAML_AUTH", False)
+    monkeypatch.setattr(backend_app, "ENABLE_MICROSOFT_AUTH", True)
+
+    response = fresh_client.get("/demoapp/login")
+    assert response.status_code == 200
+    assert "Login with Microsoft" in response.text
+    assert 'href="auth/microsoft"' in response.text
+
 
 def test_auth_user_callback(fresh_client, monkeypatch):
     """


### PR DESCRIPTION
## What changed

- add Microsoft OAuth/OIDC registration, login routes, callback handling, login-page option, and configuration documentation
- fall back to parsing the Google ID token when the token response does not contain `userinfo`
- remove unconditional authentication debug prints from every protected request
- add regression coverage for the Microsoft login option and silent authentication
- bump the Python package and frontend runtime to version `0.9.37`

## Why

Authentication validation printed session details on every protected request. Normal BFF traffic and browser log forwarding amplified those messages into hundreds of production log entries per minute. The prints were diagnostic-only and were not required for session validation.

This release also includes the staged Microsoft identity platform support.

## Impact

Authenticated requests no longer flood stdout or expose user email addresses in routine debug output. Applications can optionally enable Microsoft OAuth with the documented environment variables.

## Validation

- version consistency check: `0.9.37`
- `git diff --check`
- 48 tests passed with `test_saml_provider_metadata_route_uses_provider_config` excluded
- the excluded existing SAML metadata test currently returns HTTP 500 with its certificate fixture and is unrelated to these changes
