### PR TITLE
Support per-app favicon bundles (0.9.41)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ if __name__=="__main__":
     launch_service(
         modules_folder=".",  # point to your modules directly
         default_application="py_ui",  # optional: redirect / to /py_ui
+        favicon_folder="branding/favicon",  # optional; relative to modules_folder
         env_vars={
             "ALLOWED_EMAILS": []
         }
@@ -142,7 +143,9 @@ favicon/
 
 pyTincture scans the directory and emits the icon, size, Apple touch icon, mask icon, and web-manifest declarations browsers need. Browsers do not enumerate favicon directories themselves.
 
-For multiple applications, use one directory per application, such as `favicon/py_ui/` and `favicon/admin/`. An application can override the convention with either `APP_FAVICON = "branding/icons"` or `APP_CONFIG = {"favicon": "branding/icons"}`; the value may point to a directory or a single icon file.
+Set `favicon_folder` on `launch_service` to use a different directory. Relative paths are resolved from `modules_folder`, and absolute paths are supported, including paths outside the modules directory.
+
+For multiple applications, use one directory per application, such as `favicon/py_ui/` and `favicon/admin/`. This also works under a launcher-configured directory. An application can override both the launcher setting and the convention with either `APP_FAVICON = "branding/icons"` or `APP_CONFIG = {"favicon": "branding/icons"}`; the value may point to a directory or a single icon file under `modules_folder`.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -127,13 +127,22 @@ if __name__=="__main__":
     )
 ~~~
 
-For an app-specific browser icon, place the icon under `modules_folder` and declare its appcode-relative path in the application module:
+For one application, place the complete favicon set in a conventional `favicon` directory under `modules_folder`:
 
-```python
-APP_FAVICON = "assets/favicon.svg"
+```text
+favicon/
+  favicon.ico
+  favicon-16x16.png
+  favicon-32x32.png
+  apple-touch-icon.png
+  android-chrome-192x192.png
+  android-chrome-512x512.png
+  site.webmanifest
 ```
 
-The equivalent `APP_CONFIG = {"favicon": "assets/favicon.svg"}` form is also supported. Each application gets its own URL, such as `/py_ui/appcode/assets/favicon.svg`; `.ico`, `.png`, and `.svg` files all work.
+pyTincture scans the directory and emits the icon, size, Apple touch icon, mask icon, and web-manifest declarations browsers need. Browsers do not enumerate favicon directories themselves.
+
+For multiple applications, use one directory per application, such as `favicon/py_ui/` and `favicon/admin/`. An application can override the convention with either `APP_FAVICON = "branding/icons"` or `APP_CONFIG = {"favicon": "branding/icons"}`; the value may point to a directory or a single icon file.
 
 ## Testing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pytincture"
 
-version = "0.9.40"
+version = "0.9.41"
 
 description = "UI Builder"
 readme = "README.md"

--- a/pytincture/__init__.py
+++ b/pytincture/__init__.py
@@ -2,7 +2,7 @@
 pyTincture uvicorn launcher
 """
 
-__version__ = "0.9.40"
+__version__ = "0.9.41"
 
 from multiprocessing import Process, freeze_support
 import os

--- a/pytincture/__init__.py
+++ b/pytincture/__init__.py
@@ -55,6 +55,17 @@ def _normalize_default_application(value):
     return candidate
 
 
+def _normalize_favicon_folder(value, modules_folder):
+    candidate = os.fsdecode(os.fspath(value)).strip()
+    if not candidate:
+        raise ValueError("favicon_folder must not be empty")
+
+    candidate = os.path.expanduser(candidate)
+    if not os.path.isabs(candidate):
+        candidate = os.path.join(modules_folder, candidate)
+    return os.path.abspath(candidate)
+
+
 def main(port, ssl_keyfile=None, ssl_certfile=None, modules_folder=None):
     if modules_folder is not None:
         set_modules_path(os.fspath(modules_folder))
@@ -91,6 +102,7 @@ def launch_service(
     bff_docs_path: str = "/bff-docs",
     bff_docs_title: str = "pyTincture BFF API",
     default_application=None,
+    favicon_folder=None,
 ):
     modules_folder = os.fspath(modules_folder)
     set_modules_path(modules_folder)
@@ -107,6 +119,12 @@ def launch_service(
     if default_application is not None:
         os.environ["PYTINCTURE_DEFAULT_APPLICATION"] = (
             _normalize_default_application(default_application)
+        )
+
+    if favicon_folder is not None:
+        os.environ["PYTINCTURE_FAVICON_FOLDER"] = _normalize_favicon_folder(
+            favicon_folder,
+            modules_folder,
         )
 
     main_application = Process(target=main, args=(port, ssl_keyfile, ssl_certfile, modules_folder))

--- a/pytincture/backend/app.py
+++ b/pytincture/backend/app.py
@@ -24,7 +24,7 @@ except ValueError as exc:
 from fastapi import Depends, FastAPI, Request, Response, HTTPException, Body
 from fastapi.exceptions import RequestValidationError
 from fastapi.staticfiles import StaticFiles
-from fastapi.responses import StreamingResponse, JSONResponse, HTMLResponse, RedirectResponse
+from fastapi.responses import FileResponse, StreamingResponse, JSONResponse, HTMLResponse, RedirectResponse
 from fastapi.middleware.cors import CORSMiddleware
 from fastmcp import FastMCP
 
@@ -2359,17 +2359,22 @@ def _normalize_app_asset_path(value: Optional[str]) -> Optional[str]:
     return "/".join(segments)
 
 
-def find_app_favicon(file_path) -> Optional[str]:
-    """
-    Resolve an explicit favicon file/folder or a conventional favicon directory.
-    """
+def _find_explicit_app_favicon(file_path) -> Optional[str]:
     configured = _find_app_string_setting(
         file_path,
         assignment_names=("APP_FAVICON",),
         config_keys=("favicon",),
     )
+    return _normalize_app_asset_path(configured)
+
+
+def find_app_favicon(file_path) -> Optional[str]:
+    """
+    Resolve an explicit favicon file/folder or a conventional favicon directory.
+    """
+    configured = _find_explicit_app_favicon(file_path)
     if configured:
-        return _normalize_app_asset_path(configured)
+        return configured
 
     app_root = os.path.dirname(os.fspath(file_path))
     application = os.path.splitext(os.path.basename(os.fspath(file_path)))[0]
@@ -2406,6 +2411,46 @@ def _is_favicon_asset(filename: str) -> bool:
     )
 
 
+def _get_configured_favicon_root() -> Optional[str]:
+    configured = os.getenv("PYTINCTURE_FAVICON_FOLDER", "").strip()
+    if not configured:
+        return None
+
+    configured = os.path.expanduser(configured)
+    if not os.path.isabs(configured):
+        configured = os.path.join(get_modules_path(), configured)
+    return os.path.realpath(configured)
+
+
+def _get_configured_favicon_directory(application: str) -> Optional[str]:
+    root = _get_configured_favicon_root()
+    if not root or not os.path.isdir(root):
+        return None
+
+    if (
+        application not in ("", ".", "..")
+        and all(char.isalnum() or char in "._-" for char in application)
+    ):
+        application_folder = os.path.realpath(os.path.join(root, application))
+        try:
+            is_within_root = os.path.commonpath((root, application_folder)) == root
+        except ValueError:
+            is_within_root = False
+        if is_within_root and os.path.isdir(application_folder):
+            return application_folder
+
+    return root
+
+
+def _find_favicon_assets_in_directory(directory: str) -> List[str]:
+    assets = []
+    with os.scandir(directory) as entries:
+        for entry in sorted(entries, key=lambda item: item.name.lower()):
+            if entry.is_file(follow_symlinks=False) and _is_favicon_asset(entry.name):
+                assets.append(entry.name)
+    return assets
+
+
 def find_app_favicon_assets(file_path) -> List[str]:
     """Return the declared favicon file or supported files in its directory."""
     favicon_path = find_app_favicon(file_path)
@@ -2417,12 +2462,10 @@ def find_app_favicon_assets(file_path) -> List[str]:
     if not os.path.isdir(local_path):
         return [favicon_path]
 
-    assets = []
-    with os.scandir(local_path) as entries:
-        for entry in sorted(entries, key=lambda item: item.name.lower()):
-            if entry.is_file(follow_symlinks=False) and _is_favicon_asset(entry.name):
-                assets.append(f"{favicon_path}/{entry.name}")
-    return assets
+    return [
+        f"{favicon_path}/{filename}"
+        for filename in _find_favicon_assets_in_directory(local_path)
+    ]
 
 
 def _favicon_size(filename: str) -> Optional[str]:
@@ -2432,9 +2475,14 @@ def _favicon_size(filename: str) -> Optional[str]:
     return f"{match.group(1)}x{match.group(2)}"
 
 
-def _build_favicon_tag(application: str, asset_path: str) -> Optional[str]:
+def _build_favicon_tag(
+    application: str,
+    asset_path: str,
+    *,
+    asset_route: str = "appcode",
+) -> Optional[str]:
     favicon_url = (
-        f"/{quote(application, safe='')}/appcode/"
+        f"/{quote(application, safe='')}/{asset_route}/"
         f"{quote(asset_path, safe='/')}"
     )
     safe_url = escape(favicon_url)
@@ -2470,12 +2518,57 @@ def _build_favicon_tag(application: str, asset_path: str) -> Optional[str]:
 
 def build_app_favicon_markup(application: str, file_path) -> str:
     """Generate browser favicon declarations for an application's assets."""
+    configured_directory = None
+    if _find_explicit_app_favicon(file_path) is None:
+        configured_directory = _get_configured_favicon_directory(application)
+
+    if configured_directory is not None:
+        tags = [
+            tag
+            for asset_path in _find_favicon_assets_in_directory(configured_directory)
+            if (
+                tag := _build_favicon_tag(
+                    application,
+                    asset_path,
+                    asset_route="favicon-assets",
+                )
+            ) is not None
+        ]
+        if tags:
+            return "\n    ".join(tags)
+
     tags = [
         tag
         for asset_path in find_app_favicon_assets(file_path)
         if (tag := _build_favicon_tag(application, asset_path)) is not None
     ]
     return "\n    ".join(tags)
+
+
+@app.get(
+    "/{application}/favicon-assets/{asset_name}",
+    include_in_schema=False,
+)
+async def configured_favicon_asset(application: str, asset_name: str):
+    """Serve a browser favicon asset from the launcher-configured directory."""
+    if asset_name != os.path.basename(asset_name) or not _is_favicon_asset(asset_name):
+        raise HTTPException(status_code=404, detail="Favicon asset not found")
+
+    favicon_directory = _get_configured_favicon_directory(application)
+    if favicon_directory is None:
+        raise HTTPException(status_code=404, detail="Favicon asset not found")
+
+    asset_path = os.path.realpath(os.path.join(favicon_directory, asset_name))
+    try:
+        is_within_directory = (
+            os.path.commonpath((favicon_directory, asset_path)) == favicon_directory
+        )
+    except ValueError:
+        is_within_directory = False
+
+    if not is_within_directory or not os.path.isfile(asset_path):
+        raise HTTPException(status_code=404, detail="Favicon asset not found")
+    return FileResponse(asset_path)
 
 
 add_bff_docs_to_app(app)

--- a/pytincture/backend/app.py
+++ b/pytincture/backend/app.py
@@ -2256,18 +2256,12 @@ async def main_app_route(response: Response, application: str, request: Request)
         index_html = index_html.replace("***ENTRYPOINT***", safe_application)
     
     loading_title = application
-    favicon_link = ""
+    favicon_markup = ""
     if os.path.exists(app_file_path):
         loading_title = find_app_loading_title(app_file_path, application)
-        favicon_path = find_app_favicon(app_file_path)
-        if favicon_path:
-            favicon_url = (
-                f"/{quote(application, safe='')}/appcode/"
-                f"{quote(favicon_path, safe='/')}"
-            )
-            favicon_link = f'<link rel="icon" href="{escape(favicon_url)}">'
+        favicon_markup = build_app_favicon_markup(application, app_file_path)
     index_html = index_html.replace("***LOADING_TITLE***", escape(loading_title))
-    index_html = index_html.replace("***FAVICON_LINK***", favicon_link)
+    index_html = index_html.replace("***FAVICON_LINK***", favicon_markup)
 
     index_html = index_html.replace("***WIDGETSET***", widgetset)
     return HTMLResponse(content=index_html)
@@ -2367,14 +2361,121 @@ def _normalize_app_asset_path(value: Optional[str]) -> Optional[str]:
 
 def find_app_favicon(file_path) -> Optional[str]:
     """
-    Read APP_FAVICON or APP_CONFIG["favicon"] as an appcode-relative path.
+    Resolve an explicit favicon file/folder or a conventional favicon directory.
     """
     configured = _find_app_string_setting(
         file_path,
         assignment_names=("APP_FAVICON",),
         config_keys=("favicon",),
     )
-    return _normalize_app_asset_path(configured)
+    if configured:
+        return _normalize_app_asset_path(configured)
+
+    app_root = os.path.dirname(os.fspath(file_path))
+    application = os.path.splitext(os.path.basename(os.fspath(file_path)))[0]
+    for candidate in (f"favicon/{application}", "favicon"):
+        candidate_path = os.path.join(app_root, *candidate.split("/"))
+        if os.path.isdir(candidate_path):
+            return candidate
+    return None
+
+
+_FAVICON_MIME_TYPES = {
+    ".gif": "image/gif",
+    ".ico": "image/x-icon",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".png": "image/png",
+    ".svg": "image/svg+xml",
+    ".webp": "image/webp",
+}
+_FAVICON_MANIFEST_NAMES = {
+    "manifest.json",
+    "manifest.webmanifest",
+    "site.webmanifest",
+}
+
+
+def _is_favicon_asset(filename: str) -> bool:
+    lowered = filename.lower()
+    extension = os.path.splitext(lowered)[1]
+    return (
+        extension in _FAVICON_MIME_TYPES
+        or lowered in _FAVICON_MANIFEST_NAMES
+        or lowered == "browserconfig.xml"
+    )
+
+
+def find_app_favicon_assets(file_path) -> List[str]:
+    """Return the declared favicon file or supported files in its directory."""
+    favicon_path = find_app_favicon(file_path)
+    if not favicon_path:
+        return []
+
+    app_root = os.path.dirname(os.fspath(file_path))
+    local_path = os.path.join(app_root, *favicon_path.split("/"))
+    if not os.path.isdir(local_path):
+        return [favicon_path]
+
+    assets = []
+    with os.scandir(local_path) as entries:
+        for entry in sorted(entries, key=lambda item: item.name.lower()):
+            if entry.is_file(follow_symlinks=False) and _is_favicon_asset(entry.name):
+                assets.append(f"{favicon_path}/{entry.name}")
+    return assets
+
+
+def _favicon_size(filename: str) -> Optional[str]:
+    match = re.search(r"(?<!\d)(\d{1,4})x(\d{1,4})(?!\d)", filename)
+    if not match:
+        return None
+    return f"{match.group(1)}x{match.group(2)}"
+
+
+def _build_favicon_tag(application: str, asset_path: str) -> Optional[str]:
+    favicon_url = (
+        f"/{quote(application, safe='')}/appcode/"
+        f"{quote(asset_path, safe='/')}"
+    )
+    safe_url = escape(favicon_url)
+    filename = os.path.basename(asset_path).lower()
+
+    if filename in _FAVICON_MANIFEST_NAMES:
+        return f'<link rel="manifest" href="{safe_url}">'
+    if filename == "browserconfig.xml":
+        return f'<meta name="msapplication-config" content="{safe_url}">'
+
+    extension = os.path.splitext(filename)[1]
+    mime_type = _FAVICON_MIME_TYPES.get(extension)
+    if not mime_type:
+        return None
+
+    if filename.startswith("apple-touch-icon-precomposed"):
+        relation = "apple-touch-icon-precomposed"
+    elif filename.startswith("apple-touch-icon"):
+        relation = "apple-touch-icon"
+    elif "mask-icon" in filename or filename == "safari-pinned-tab.svg":
+        relation = "mask-icon"
+    else:
+        relation = "icon"
+
+    attributes = [f'rel="{relation}"', f'href="{safe_url}"', f'type="{mime_type}"']
+    size = _favicon_size(filename)
+    if size:
+        attributes.append(f'sizes="{size}"')
+    elif extension == ".svg":
+        attributes.append('sizes="any"')
+    return f"<link {' '.join(attributes)}>"
+
+
+def build_app_favicon_markup(application: str, file_path) -> str:
+    """Generate browser favicon declarations for an application's assets."""
+    tags = [
+        tag
+        for asset_path in find_app_favicon_assets(file_path)
+        if (tag := _build_favicon_tag(application, asset_path)) is not None
+    ]
+    return "\n    ".join(tags)
 
 
 add_bff_docs_to_app(app)

--- a/pytincture/frontend/package.json
+++ b/pytincture/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pytincture/runtime",
-  "version": "0.9.40",
+  "version": "0.9.41",
   "description": "Standalone pytincture.js runtime with inline app auto-start support.",
   "type": "module",
   "main": "dist/pytincture.js",

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1181,6 +1181,55 @@ def test_favicon_folder_prefers_application_specific_directory(tmp_path):
     assert backend_app.find_app_favicon(app_file) == "favicon/demoapp"
 
 
+def test_launcher_favicon_folder_supports_external_path(monkeypatch, tmp_path):
+    import pytincture.backend.app as backend_app
+
+    modules_folder = tmp_path / "modules"
+    modules_folder.mkdir()
+    app_file = modules_folder / "demoapp.py"
+    app_file.write_text("# use launcher favicon folder\n")
+
+    favicon_folder = tmp_path / "shared-branding"
+    favicon_folder.mkdir()
+    (favicon_folder / "favicon-32x32.png").write_bytes(b"configured-icon")
+    monkeypatch.setenv("PYTINCTURE_FAVICON_FOLDER", str(favicon_folder))
+
+    markup = backend_app.build_app_favicon_markup("demoapp", app_file)
+
+    assert 'href="/demoapp/favicon-assets/favicon-32x32.png"' in markup
+    assert 'sizes="32x32"' in markup
+
+
+def test_launcher_favicon_folder_serves_per_app_assets(fresh_client, monkeypatch, tmp_path):
+    favicon_root = tmp_path / "favicons"
+    app_favicon_folder = favicon_root / "demoapp"
+    app_favicon_folder.mkdir(parents=True)
+    (favicon_root / "favicon.ico").write_bytes(b"shared-icon")
+    (app_favicon_folder / "favicon.ico").write_bytes(b"demo-icon")
+    monkeypatch.setenv("PYTINCTURE_FAVICON_FOLDER", str(favicon_root))
+
+    response = fresh_client.get("/demoapp/favicon-assets/favicon.ico")
+
+    assert response.status_code == 200
+    assert response.content == b"demo-icon"
+
+
+def test_app_favicon_setting_overrides_launcher_folder(monkeypatch, tmp_path):
+    import pytincture.backend.app as backend_app
+
+    app_file = tmp_path / "demoapp.py"
+    app_file.write_text('APP_FAVICON = "branding/app-icon.svg"\n')
+    favicon_folder = tmp_path / "launcher-favicons"
+    favicon_folder.mkdir()
+    (favicon_folder / "favicon.ico").write_bytes(b"launcher-icon")
+    monkeypatch.setenv("PYTINCTURE_FAVICON_FOLDER", str(favicon_folder))
+
+    markup = backend_app.build_app_favicon_markup("demoapp", app_file)
+
+    assert 'href="/demoapp/appcode/branding/app-icon.svg"' in markup
+    assert "favicon-assets" not in markup
+
+
 def test_find_app_favicon_rejects_unsafe_asset_paths(tmp_path):
     import pytincture.backend.app as backend_app
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1130,9 +1130,55 @@ def test_main_app_route_includes_per_app_favicon(fresh_client, monkeypatch, tmp_
 
     assert response.status_code == 200
     assert (
-        '<link rel="icon" href="/demoapp/appcode/assets/demo%20icon.svg">'
+        '<link rel="icon" href="/demoapp/appcode/assets/demo%20icon.svg" '
+        'type="image/svg+xml" sizes="any">'
         in response.text
     )
+
+
+def test_favicon_folder_declares_available_browser_assets(tmp_path):
+    import pytincture.backend.app as backend_app
+
+    app_file = tmp_path / "demoapp.py"
+    app_file.write_text("# favicon folder uses convention-based discovery\n")
+    favicon_folder = tmp_path / "favicon"
+    favicon_folder.mkdir()
+    for filename in (
+        "android-chrome-192x192.png",
+        "apple-touch-icon.png",
+        "favicon-16x16.ico",
+        "favicon-32x32.png",
+        "favicon.ico",
+        "safari-pinned-tab.svg",
+        "site.webmanifest",
+    ):
+        (favicon_folder / filename).write_bytes(b"icon")
+    (favicon_folder / "notes.txt").write_text("not a browser favicon asset")
+
+    markup = backend_app.build_app_favicon_markup("demoapp", app_file)
+
+    assert 'href="/demoapp/appcode/favicon/favicon.ico"' in markup
+    assert 'href="/demoapp/appcode/favicon/favicon-16x16.ico"' in markup
+    assert 'sizes="16x16"' in markup
+    assert 'href="/demoapp/appcode/favicon/favicon-32x32.png"' in markup
+    assert 'sizes="32x32"' in markup
+    assert 'rel="apple-touch-icon"' in markup
+    assert 'rel="mask-icon"' in markup
+    assert 'rel="manifest"' in markup
+    assert "notes.txt" not in markup
+
+
+def test_favicon_folder_prefers_application_specific_directory(tmp_path):
+    import pytincture.backend.app as backend_app
+
+    app_file = tmp_path / "demoapp.py"
+    app_file.write_text("# app-specific favicon folder\n")
+    (tmp_path / "favicon").mkdir()
+    app_favicon_folder = tmp_path / "favicon" / "demoapp"
+    app_favicon_folder.mkdir()
+    (app_favicon_folder / "favicon.ico").write_bytes(b"icon")
+
+    assert backend_app.find_app_favicon(app_file) == "favicon/demoapp"
 
 
 def test_find_app_favicon_rejects_unsafe_asset_paths(tmp_path):

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -77,6 +77,8 @@ def test_launch_service(monkeypatch, tmp_path):
     # Create a dummy folder using tmp_path so that the directory exists.
     dummy_folder = tmp_path / "dummy_folder"
     dummy_folder.mkdir()
+    favicon_folder = dummy_folder / "branding" / "favicon"
+    favicon_folder.mkdir(parents=True)
     test_folder = str(dummy_folder)
     test_port = 8080
     env_vars = {"TEST_VAR": "value"}
@@ -85,6 +87,7 @@ def test_launch_service(monkeypatch, tmp_path):
     os.environ.pop("MODULES_PATH", None)
     os.environ.pop("TEST_VAR", None)
     os.environ.pop("PYTINCTURE_DEFAULT_APPLICATION", None)
+    os.environ.pop("PYTINCTURE_FAVICON_FOLDER", None)
 
     # Call launch_service.
     from pytincture.__init__ import launch_service
@@ -93,6 +96,7 @@ def test_launch_service(monkeypatch, tmp_path):
         port=test_port,
         env_vars=env_vars,
         default_application="demoapp",
+        favicon_folder="branding/favicon",
     )
 
     # Verify that the module path was stored and env vars applied.
@@ -100,6 +104,7 @@ def test_launch_service(monkeypatch, tmp_path):
     assert os.environ["MODULES_PATH"] == test_folder
     assert os.environ["TEST_VAR"] == "value"
     assert os.environ["PYTINCTURE_DEFAULT_APPLICATION"] == "demoapp"
+    assert os.environ["PYTINCTURE_FAVICON_FOLDER"] == str(favicon_folder)
 
     # Check that our FakeProcess methods were called.
     assert "start" in process_calls
@@ -108,6 +113,7 @@ def test_launch_service(monkeypatch, tmp_path):
     os.environ.pop("MODULES_PATH", None)
     os.environ.pop("TEST_VAR", None)
     os.environ.pop("PYTINCTURE_DEFAULT_APPLICATION", None)
+    os.environ.pop("PYTINCTURE_FAVICON_FOLDER", None)
 
 
 def test_launch_service_ignores_env_var_override(monkeypatch, tmp_path):


### PR DESCRIPTION
## What changed
- discover standard favicon files from a favicon folder
- support per-application favicon subfolders with explicit configuration precedence
- emit icon, Apple touch icon, manifest, mask icon, and browserconfig metadata
- bump Python and frontend package versions to 0.9.41

## Why
Applications need complete browser favicon bundles instead of being limited to one configured icon file.

## Impact
Single-app services can place files directly in favicon/. Multi-app services can use favicon/<application>/, while APP_FAVICON and APP_CONFIG favicon values remain supported.

## Validation
- 61 applicable tests passed
- Python compilation passed
- wheel build passed
- git diff validation passed