### PR TITLE
Security hardening and replay protection for 0.10.0

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,14 @@
-recursive-include pytincture/frontend *
+include pytincture/frontend/index.html
+include pytincture/frontend/pytincture.js
+include pytincture/frontend/sw.js
+recursive-include pytincture/frontend/dist *
+recursive-include pytincture/frontend/pyodide *
+exclude pytincture/frontend/README.md
+exclude pytincture/frontend/package.json
+exclude pytincture/frontend/package-lock.json
+exclude pytincture/frontend/build.mjs
+exclude pytincture/frontend/sync-version.mjs
+prune pytincture/frontend/node_modules
+prune pytincture/frontend/__pycache__
+prune build
+global-exclude *.py[cod]

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 ## Features
 - Pyodide Integration: Seamlessly bring Python to the web via Pyodide.
 - GUI Library Support: Simplify the creation and management of GUI components in Python.
-- Dynamic Code Packaging: Generate in-memory ZIP packages for frontend consumption.
+- Browser-safe Code Packaging: Package the application entrypoint, reachable local imports, and explicitly configured browser files.
 - Widgetset Stub Generation: Automatically generate frontend stub classes using the @backend_for_frontend decorator.
 - Streaming BFF Calls: Enable true streaming responses with the @bff_stream decorator.
-- Authentication & Sessions: Supports Google and Microsoft OAuth2, SAML 2.0 SSO, and email/password authentication with compact signed sessions that work across replicas.
+- Authentication & Sessions: Supports Google and Microsoft OAuth2, SAML 2.0 SSO, verified email/password login, key rotation, CSRF protection, and revocable signed sessions.
 - Redis Integration: Optionally expose the legacy shared `USER_SESSION_DICT` through Upstash; authentication does not require Redis.
 - Cross-Platform Compatibility: Works on any platform where Pyodide is supported.
 - Easy to Use: Provides a user-friendly API to streamline GUI development.
@@ -39,8 +39,13 @@ pip install .
 ## Environment Variables
 - MODULES_PATH: Directory containing module files used for dynamic packaging. This is set automatically from `modules_folder` when `launch_service` starts; overriding it via env vars is usually unnecessary.
 - USE_REDIS_INSTANCE: Set to "true" to back the legacy `USER_SESSION_DICT` with Upstash. Authentication does not read or write this dictionary.
-- ALLOWED_EMAILS: A comma-separated list of authorized email addresses.
+- ALLOWED_EMAILS: An optional comma-separated authorization allowlist. It is not a password verifier.
    example: "some@email.com,joe@email.com"
+- ENABLE_USER_LOGIN: Enable verified local email/password login. This route is rejected when the flag is false.
+- AUTH_PASSWORD_HASHES: JSON object mapping normalized email addresses to Argon2id or bcrypt hashes.
+   example: `{"user@example.com":"$argon2id$..."}`
+- AUTH_USER_AUTHENTICATOR: Optional dotted path to a sync or async callable accepting `email`, `password`, and `request`. It must return trusted user claims, `True`, or `False`.
+- ENABLE_DEV_EMAIL_LOGIN: Allow a non-empty `ALLOWED_EMAILS` list without password verification only on loopback hosts. This is intentionally unsafe and must only be set to `true` for local development.
 - ENABLE_GOOGLE_AUTH: Enable the respective authentication mechanisms.
    example: "true"
 - ENABLE_MICROSOFT_AUTH: Enable Microsoft OAuth2 authentication using the shared `common` tenant endpoint.
@@ -59,9 +64,11 @@ pip install .
    example: "Login with Contoso"
 - SAML_LOGO_URL: Optional image URL for the single-provider SAML login button.
    example: "/appcode/contoso-logo.svg"
-- SAML_SECRET_KEY: Primary signing key for stateless authentication cookies and SAML RelayState. Use at least 32 random characters, keep it stable across deployments, and provide the same value to every replica. When configured, secure cookies default to enabled.
+- SAML_SECRET_KEY: Required whenever any production authentication method is enabled. Use at least 32 random characters, keep it stable across deployments, and provide the same value to every replica. Generate one with `python -c "import secrets; print(secrets.token_urlsafe(32))"`. Loopback development login may use an ephemeral generated key.
+- AUTH_SESSION_PREVIOUS_SECRET_KEYS: JSON list (or comma-separated list) of prior strong signing keys accepted during rotation. Cookies accepted with an old key are re-signed with the current key.
 - AUTH_SESSION_MAX_AGE_SECONDS: Signed authentication cookie lifetime in seconds. Defaults to `28800` (8 hours).
-- AUTH_SESSION_HTTPS_ONLY: Set to `true` to require HTTPS for the authentication cookie. Defaults to `true` when `SAML_SECRET_KEY` is configured and `false` only for legacy/local compatibility.
+- AUTH_SESSION_HTTPS_ONLY: Require HTTPS for authentication and CSRF cookies. Defaults to `true`; loopback development login defaults it to `false` unless explicitly overridden.
+- AUTH_SESSION_SAME_SITE: Cookie SameSite policy: `lax`, `strict`, or `none`. Defaults to `lax`.
 - SAML_RELAY_STATE_TTL_SECONDS: Maximum SAML login handshake age in seconds. Defaults to `600` (10 minutes).
 - SAML_DEFAULT_REDIRECT: Optional redirect path or URL template after SAML login (defaults to `/{application}` when unset).
    example: "/{application}"
@@ -107,8 +114,23 @@ pip install .
 - REDIS_UPSTASH_INSTANCE_TOKEN: Redis Upstash token
 - DATABASE_URL: Database connection string
    example: "sqlite:////absolute/path/to/database.db"
+- PYTINCTURE_BROWSER_FILES: JSON list or comma-separated globs for extra files to include in the browser package. Python entrypoints and reachable local imports are discovered automatically.
+- PYTINCTURE_PUBLIC_ASSET_PATHS: Explicit globs for files that may be served from `/{application}/appcode/` in addition to standard image, font, media, CSS, and JavaScript assets. Python and configuration files are denied by default.
+- MAX_REQUEST_BODY_BYTES: Maximum request body size. Defaults to 2 MiB.
+- BFF_CALL_TIMEOUT_SECONDS: Maximum non-streaming BFF execution time. Defaults to 30 seconds.
+- BFF_STREAM_MAX_SECONDS: Maximum BFF stream duration. Defaults to 300 seconds.
+- BFF_STREAM_MAX_BYTES: Maximum BFF stream output. Defaults to 10 MiB.
+- BFF_POLICY_HOOK_PATH: Dotted path to a sync or async policy hook. This is the recommended launcher configuration because the hook must be available before application modules are imported or constructed.
+- ENABLE_BFF_REPLAY_TOKENS: Opt-in one-time request proofs for authenticated BFF calls. Generated browser stubs automatically obtain, consume, and refill an in-memory token pool. Defaults to `false`.
+- BFF_REPLAY_TOKEN_BATCH_SIZE: Number of one-time proofs returned in each opaque refill. Defaults to `12`.
+- BFF_REPLAY_TOKEN_LOW_WATERMARK: Refill the browser-side pool when this many proofs remain. Defaults to `3`.
+- BFF_REPLAY_TOKEN_TTL_SECONDS: Lifetime of an unused proof. Defaults to `300` seconds.
+- ENABLE_MCP: Enable the MCP mount. MCP exports no tools by default.
+- MCP_EXPOSED_OPERATIONS: JSON list of explicitly allowed FastAPI operation IDs. Login, session, logging, application delivery, and appcode download operations cannot be exported.
 
-Authenticated browser cookies contain only stable identity claims such as email, name, provider, roles, and picture. Passwords, complete SAML attributes, SAML assertions, and changing SAML session indexes are not stored in the cookie. BFF classes and policy hooks continue to receive the compact authenticated identity.
+Authenticated browser cookies contain only stable identity claims plus opaque session and CSRF identifiers. Passwords, complete SAML attributes, SAML assertions, and changing SAML session indexes are not stored in the cookie. Logout revokes the current session; Upstash-backed services share revocations between replicas.
+
+When `ENABLE_BFF_REPLAY_TOKENS=true`, each authenticated `.pyt` download receives a random, short-lived client decoder and an opaque session-bound capsule. Token refills return an authenticated opaque payload rather than a visible JSON token list. The capsule is recoverable after backend restarts as long as `SAML_SECRET_KEY` remains stable. Without Upstash, already-issued tokens are intentionally invalidated by a backend restart and generated stubs transparently refill them. This feature makes copied completed BFF requests fail and adds a reverse-engineering barrier; it is not a security boundary against a user who controls the browser, WASM memory, or application archive.
 
 ## Running the Service with your application
 -------------------
@@ -123,7 +145,10 @@ if __name__=="__main__":
         default_application="py_ui",  # optional: redirect / to /py_ui
         favicon_folder="branding/favicon",  # optional; relative to modules_folder
         env_vars={
-            "ALLOWED_EMAILS": []
+            "ENABLE_USER_LOGIN": "true",
+            "ENABLE_DEV_EMAIL_LOGIN": "true",
+            "ALLOWED_EMAILS": "developer@example.com",
+            "AUTH_SESSION_HTTPS_ONLY": "false",
         }
     )
 ~~~
@@ -220,7 +245,21 @@ With the CDN script on the page, pytincture auto-detects any `<script type="text
 Errors are rendered inside `#maindiv` (if present) and logged to the console, making it easy to host pure-static demos without the full framework.
 
 ### Backend-for-Frontend access policies
-Every `@backend_for_frontend` class exposes its methods via `/classcall`, but you can now gate each method without modifying pytincture core:
+Only classes marked with `@backend_for_frontend` and their public methods/attributes are registered. Unknown targets are rejected from a static manifest before application code is imported or constructed. Methods default to POST.
+
+Use `@bff_http_methods` to opt a side-effect-free method into GET or to select PUT, PATCH, or DELETE:
+
+```python
+from pytincture.dataclass import backend_for_frontend, bff_http_methods
+
+@backend_for_frontend
+class Reports:
+    @bff_http_methods("GET")
+    def status(self):
+        return {"ready": True}
+```
+
+Policy metadata must use literal values so it can be read without importing the module. Hooks may be synchronous or asynchronous and run before module import, construction, or attribute access:
 
 1. Tag the method with `@bff_policy(...)` to describe whatever metadata you need (roles, scopes, tenants, etc.):
    ```python
@@ -246,7 +285,21 @@ Every `@backend_for_frontend` class exposes its methods via `/classcall`, but yo
    set_bff_policy_hook(my_policy_hook)
    ```
 
-Because the authorization decision lives on the server, even an authenticated user who opens the browser console can’t call methods they don’t have rights to. The hook is optional—if you don’t register one, `bff_policy` metadata is ignored.
+Because the authorization decision lives on the server, even an authenticated user who opens the browser console can’t call methods they don’t have rights to. The hook is optional—if you don’t register one, `bff_policy` metadata is ignored. Cookie-authenticated state-changing calls also require the CSRF token automatically sent by generated browser stubs.
+
+### 0.10 security migration
+
+Version 0.10 intentionally removes insecure legacy behavior:
+
+- configure a strong `SAML_SECRET_KEY` before enabling authentication;
+- configure `AUTH_PASSWORD_HASHES` or `AUTH_USER_AUTHENTICATOR` for local login, or use `ENABLE_DEV_EMAIL_LOGIN` only on loopback during development;
+- decorate every remotely callable class with `@backend_for_frontend`;
+- change manually issued GET method calls to POST or declare `@bff_http_methods("GET")`;
+- explicitly list extra browser package files and public assets;
+- explicitly opt in to MCP operations;
+- update custom cookie-based clients to echo the `pytincture_csrf` cookie in `X-CSRF-Token` for POST, PUT, PATCH, and DELETE.
+
+Pytincture does not currently provide rate limiting. Production deployments should enforce suitable login and request rates at the application gateway or reverse proxy.
 
 ### CI/CD release flow
 Publishing a GitHub release (or manually triggering the `Publish to PyPI` workflow) now runs the following automatically:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,11 +5,11 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pytincture"
 
-version = "0.9.41"
+version = "0.10.0"
 
 description = "UI Builder"
 readme = "README.md"
-license = { text = "MIT" }
+license = "MIT"
 requires-python = ">=3.13,<3.15"
 authors = [
     { name = "Your Name", email = "schapman1974@gmail.com" }
@@ -34,11 +34,12 @@ dependencies = [
     "python-dotenv==1.2.1",
     "aioredis==2.0.1",
     "pytest==9.0.2",
-    "nest-asyncio==1.6.0",
     "python3-saml==1.16.0",
     "markupsafe==3.0.3",
     "itsdangerous==2.2.0",
     "python-multipart==0.0.22",
+    "argon2-cffi==25.1.0",
+    "bcrypt==5.0.0",
     "xmlsec>=1.3.17",
 ]
 
@@ -46,10 +47,16 @@ dependencies = [
 Homepage = "https://github.com/pytincture/pytincture"
 
 [tool.setuptools.packages]
-find = {}
+find = { include = ["pytincture*"] }
 
 [tool.setuptools]
-include-package-data = true
+include-package-data = false
 
 [tool.setuptools.package-data]
-pytincture = ["frontend/**/*"]
+pytincture = [
+    "frontend/index.html",
+    "frontend/pytincture.js",
+    "frontend/sw.js",
+    "frontend/dist/*",
+    "frontend/pyodide/**/*",
+]

--- a/pytincture/__init__.py
+++ b/pytincture/__init__.py
@@ -2,7 +2,7 @@
 pyTincture uvicorn launcher
 """
 
-__version__ = "0.9.41"
+__version__ = "0.10.0"
 
 from multiprocessing import Process, freeze_support
 import os

--- a/pytincture/backend/app.py
+++ b/pytincture/backend/app.py
@@ -9,17 +9,16 @@ import io
 import zipfile
 import importlib
 import asyncio
-import nest_asyncio
 import base64
 import hashlib
+import hmac
+import logging
+import secrets
+import time
+import uuid
+import fnmatch
+import copy
 from xml.etree import ElementTree
-try:
-    nest_asyncio.apply()
-except ValueError as exc:
-    # uvloop event loops cannot be patched; skip when uvloop is active.
-    if "uvloop" not in str(exc):
-        raise
-
 # FastAPI / Starlette
 from fastapi import Depends, FastAPI, Request, Response, HTTPException, Body
 from fastapi.exceptions import RequestValidationError
@@ -30,13 +29,16 @@ from fastmcp import FastMCP
 
 # Pytincture
 from pytincture import get_modules_path
-from pytincture.dataclass import get_parsed_output, add_bff_docs_to_app
+from pytincture.dataclass import get_parsed_output, add_bff_docs_to_app, get_bff_manifest
 from importlib.machinery import SourceFileLoader
 
 # Google OAuth via Authlib
 from authlib.integrations.starlette_client import OAuth, OAuthError
-from itsdangerous import BadSignature, SignatureExpired, URLSafeTimedSerializer
+from itsdangerous import BadSignature, SignatureExpired, TimestampSigner, URLSafeTimedSerializer
 from starlette.middleware.sessions import SessionMiddleware
+from starlette.datastructures import MutableHeaders
+from starlette.requests import HTTPConnection
+from starlette.concurrency import run_in_threadpool
 from starlette.config import Config
 
 from typing import Any, Union, Dict, List, Optional, Iterable, AsyncIterable, Set, Callable
@@ -56,6 +58,107 @@ from html import escape
 # ========================
 
 app = FastAPI(title="pyTincture API")
+logger = logging.getLogger("pytincture.security")
+
+
+class RotatingSessionMiddleware(SessionMiddleware):
+    """Starlette sessions that accept old signing keys and re-sign with the current key."""
+
+    def __init__(self, app, secret_key, previous_secret_keys=None, **kwargs):
+        super().__init__(app, secret_key=secret_key, **kwargs)
+        self.previous_signers = [
+            TimestampSigner(str(key)) for key in (previous_secret_keys or []) if str(key)
+        ]
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] not in ("http", "websocket"):
+            await self.app(scope, receive, send)
+            return
+
+        connection = HTTPConnection(scope)
+        initial_session_was_empty = True
+        if self.session_cookie in connection.cookies:
+            signed_data = connection.cookies[self.session_cookie].encode("utf-8")
+            for signer in (self.signer, *self.previous_signers):
+                try:
+                    decoded = signer.unsign(signed_data, max_age=self.max_age)
+                    scope["session"] = json.loads(base64.b64decode(decoded))
+                    initial_session_was_empty = False
+                    break
+                except (BadSignature, ValueError, json.JSONDecodeError):
+                    continue
+            else:
+                scope["session"] = {}
+        else:
+            scope["session"] = {}
+
+        async def send_wrapper(message):
+            if message["type"] == "http.response.start":
+                headers = MutableHeaders(scope=message)
+                if scope["session"]:
+                    data = base64.b64encode(json.dumps(scope["session"]).encode("utf-8"))
+                    signed = self.signer.sign(data).decode("utf-8")
+                    max_age = f"Max-Age={self.max_age}; " if self.max_age else ""
+                    headers.append(
+                        "Set-Cookie",
+                        f"{self.session_cookie}={signed}; path={self.path}; "
+                        f"{max_age}{self.security_flags}",
+                    )
+                elif not initial_session_was_empty:
+                    headers.append(
+                        "Set-Cookie",
+                        f"{self.session_cookie}=null; path={self.path}; "
+                        f"expires=Thu, 01 Jan 1970 00:00:00 GMT; {self.security_flags}",
+                    )
+            await send(message)
+
+        await self.app(scope, receive, send_wrapper)
+
+
+class RequestBodyLimitMiddleware:
+    """Reject request bodies that exceed the configured byte limit."""
+
+    def __init__(self, app, max_bytes: int):
+        self.app = app
+        self.max_bytes = max_bytes
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+        headers = dict(scope.get("headers") or [])
+        content_length = headers.get(b"content-length")
+        if content_length:
+            try:
+                if int(content_length) > self.max_bytes:
+                    response = JSONResponse(
+                        {"detail": "Request body too large"}, status_code=413
+                    )
+                    await response(scope, receive, send)
+                    return
+            except ValueError:
+                response = JSONResponse({"detail": "Invalid Content-Length"}, status_code=400)
+                await response(scope, receive, send)
+                return
+
+        received = 0
+
+        async def limited_receive():
+            nonlocal received
+            message = await receive()
+            if message.get("type") == "http.request":
+                received += len(message.get("body", b""))
+                if received > self.max_bytes:
+                    raise HTTPException(status_code=413, detail="Request body too large")
+            return message
+
+        try:
+            await self.app(scope, limited_receive, send)
+        except HTTPException as exc:
+            if exc.status_code != 413:
+                raise
+            response = JSONResponse({"detail": "Request body too large"}, status_code=413)
+            await response(scope, receive, send)
 
 
 def _build_streamable_mcp_app(mcp_server, path: str = "/"):
@@ -119,6 +222,60 @@ def _load_source_module(file_path: str, name_hint: str):
 
     return module
 
+class _FilteredFastAPIApp:
+    def __init__(self, source_app: FastAPI, operation_ids: Set[str]):
+        self.source_app = source_app
+        self.operation_ids = operation_ids
+        self.title = source_app.title
+
+    def openapi(self):
+        schema = copy.deepcopy(self.source_app.openapi())
+        filtered_paths = {}
+        for path, path_item in schema.get("paths", {}).items():
+            selected = {
+                key: value
+                for key, value in path_item.items()
+                if key not in {"get", "post", "put", "patch", "delete", "options", "head"}
+                or value.get("operationId") in self.operation_ids
+            }
+            if any(key in selected for key in {"get", "post", "put", "patch", "delete"}):
+                filtered_paths[path] = selected
+        schema["paths"] = filtered_paths
+        return schema
+
+    async def __call__(self, scope, receive, send):
+        await self.source_app(scope, receive, send)
+
+
+def _mcp_operation_ids() -> Set[str]:
+    if os.getenv("ENABLE_MCP", "false").lower() != "true":
+        return set()
+    raw = os.getenv("MCP_EXPOSED_OPERATIONS", "[]")
+    try:
+        configured = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("MCP_EXPOSED_OPERATIONS must be a JSON list") from exc
+    if not isinstance(configured, list) or any(not isinstance(value, str) for value in configured):
+        raise RuntimeError("MCP_EXPOSED_OPERATIONS must be a JSON list")
+    forbidden = {
+        "handleUserAuth", "mcpAuth", "logoutUser", "postLogs",
+        "downloadAppcodePackage", "getLoginPage", "getMainApp",
+        "issueBffReplayTokens",
+        "initiateGoogleAuth", "handleGoogleAuthCallback",
+        "initiateMicrosoftAuth", "handleMicrosoftAuthCallback",
+        "initiateSamlAuth", "initiateSamlProviderAuth",
+        "handleSamlAuthCallback", "handleSamlProviderAuthCallback",
+    }
+    requested = set(configured)
+    disallowed = requested & forbidden
+    if disallowed:
+        raise RuntimeError(
+            "MCP_EXPOSED_OPERATIONS contains session/login/application routes: "
+            + ", ".join(sorted(disallowed))
+        )
+    return requested
+
+
 def reload_mcp_tools():
     global mcp, mcp_http_app  # Use globals or pass as needed if in a class/module
     
@@ -129,26 +286,13 @@ def reload_mcp_tools():
         if not route.path.startswith("/mcp")
     ]
     
-    # Step 2: Recreate FastMCP instance (rescans app for new endpoints/tools)
-    mcp = FastMCP.from_fastapi(app=app, name="short")  # Add name="short" to reduce prefixed/suffixed lengths
-    print("MCP Tools reloaded successfully.")
-    
-    # Test tool name lengths
-    print("\nTesting MCP Tool Name Lengths:")
-    try:
-        loop = asyncio.get_running_loop()
-    except RuntimeError:
-        loop = None
-
-    if loop is not None and loop.is_running():
-        print("Skipping MCP tool length test: event loop already running.")
+    operation_ids = _mcp_operation_ids()
+    if operation_ids:
+        mcp_source = _FilteredFastAPIApp(app, operation_ids)
+        mcp = FastMCP.from_fastapi(app=mcp_source, name="pytincture")
     else:
-        tools = asyncio.run(mcp.get_tools())
-        for tool in tools.values():
-            name_length = len(tool.name)
-            print(f"Tool: {tool.name} | Length: {name_length} chars | Over Limit: {name_length > 64}")
-            if name_length > 64:
-                print(f"  WARNING: Exceeds 64-char limit! Suggested truncate: {tool.name[:61]}...")
+        mcp = FastMCP(name="pytincture")
+    logger.info("MCP tools reloaded for operations: %s", sorted(operation_ids))
     
     # Step 3: Recreate MCP app using streamable HTTP transport
     mcp_http_app = _build_streamable_mcp_app(mcp, path='/')
@@ -156,25 +300,97 @@ def reload_mcp_tools():
     # Step 4: Remount the updated MCP app
     app.mount("/mcp", mcp_http_app)
 
-def create_appcode_pkg_in_memory(host, protocol):
-    """Generate an appcode package in memory for the browser to pull for the frontend."""
-    appcode_folder = get_modules_path()
+def _local_python_imports(file_path: str, modules_root: str) -> Set[str]:
+    """Return local Python files directly imported by a browser module."""
+    try:
+        with open(file_path, "r", encoding="utf-8") as source_file:
+            tree = ast.parse(source_file.read(), filename=file_path)
+    except (OSError, SyntaxError):
+        return set()
+    discovered: Set[str] = set()
+    for node in ast.walk(tree):
+        candidates: List[str] = []
+        if isinstance(node, ast.Import):
+            candidates.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            candidates.append(node.module)
+        for module_name in candidates:
+            relative = module_name.replace(".", os.sep)
+            for candidate in (
+                os.path.join(modules_root, f"{relative}.py"),
+                os.path.join(modules_root, relative, "__init__.py"),
+            ):
+                if os.path.isfile(candidate):
+                    discovered.add(os.path.abspath(candidate))
+    return discovered
+
+
+def _configured_browser_files(modules_root: str) -> Set[str]:
+    raw_patterns = os.getenv("PYTINCTURE_BROWSER_FILES", "").strip()
+    if not raw_patterns:
+        return set()
+    try:
+        patterns = json.loads(raw_patterns)
+    except json.JSONDecodeError:
+        patterns = [value.strip() for value in raw_patterns.split(",") if value.strip()]
+    if not isinstance(patterns, list) or any(not isinstance(value, str) for value in patterns):
+        raise RuntimeError("PYTINCTURE_BROWSER_FILES must be a JSON list or comma-separated globs")
+    selected: Set[str] = set()
+    for root, dirs, files in os.walk(modules_root):
+        dirs[:] = [
+            directory
+            for directory in dirs
+            if not directory.startswith(".")
+            and directory
+            not in {"__pycache__", ".venv", "venv", "node_modules", "build", "dist"}
+        ]
+        for filename in files:
+            absolute = os.path.abspath(os.path.join(root, filename))
+            relative = os.path.relpath(absolute, modules_root).replace(os.sep, "/")
+            if any(fnmatch.fnmatch(relative, pattern) for pattern in patterns):
+                selected.add(absolute)
+    return selected
+
+
+def _browser_package_files(application: str) -> Set[str]:
+    modules_root = os.path.abspath(get_modules_path())
+    entrypoint = os.path.abspath(os.path.join(modules_root, f"{application}.py"))
+    if os.path.commonpath((modules_root, entrypoint)) != modules_root or not os.path.isfile(entrypoint):
+        raise HTTPException(status_code=404, detail="Application entrypoint not found")
+    selected = {entrypoint}
+    pending = [entrypoint]
+    while pending:
+        for imported in _local_python_imports(pending.pop(), modules_root):
+            if imported not in selected:
+                selected.add(imported)
+                pending.append(imported)
+    for python_file in tuple(selected):
+        parent = os.path.dirname(python_file)
+        while parent != modules_root and os.path.commonpath((modules_root, parent)) == modules_root:
+            package_init = os.path.join(parent, "__init__.py")
+            if os.path.isfile(package_init):
+                selected.add(os.path.abspath(package_init))
+            parent = os.path.dirname(parent)
+    return selected | _configured_browser_files(modules_root)
+
+
+def create_appcode_pkg_in_memory(host, protocol, application, replay_client=None):
+    """Generate an explicit browser-safe app package in memory."""
+    appcode_folder = os.path.abspath(get_modules_path())
     in_memory_zip = io.BytesIO()
     with zipfile.ZipFile(in_memory_zip, 'w', zipfile.ZIP_DEFLATED) as zipf:
-        for root, dirs, files in os.walk(appcode_folder):
-            for file in files:
-                file_path = os.path.join(root, file)
-                arcname = os.path.relpath(file_path, appcode_folder)
-                if not (file.endswith('.zip') or file.endswith('.pyt') or file.endswith('.pyc') or file.endswith('.whl') or file.startswith('.')):
-                    if "__pycache__" not in root and ".venv" not in root:
-                        if file.endswith('.py'):
-                            file_contents = get_parsed_output(file_path, host, protocol)
-                            if os.path.getsize(file_path) != 0:
-                                zipf.writestr(arcname, file_contents)
-                            else:
-                                zipf.write(file_path, arcname)
-                        else:
-                            zipf.write(file_path, arcname)
+        for file_path in sorted(_browser_package_files(application)):
+            arcname = os.path.relpath(file_path, appcode_folder).replace(os.sep, "/")
+            if file_path.endswith('.py'):
+                file_contents = get_parsed_output(
+                    file_path,
+                    host,
+                    protocol,
+                    replay_client=replay_client,
+                )
+                zipf.writestr(arcname, file_contents or "")
+            else:
+                zipf.write(file_path, arcname)
     in_memory_zip.seek(0)
     return in_memory_zip
 
@@ -211,9 +427,63 @@ async def favicon():
 
 @app.exception_handler(RequestValidationError)
 async def validation_exception_handler(request, exc):
+    sanitized_errors = [
+        {
+            key: value
+            for key, value in error.items()
+            if key in {"loc", "msg", "type"}
+        }
+        for error in exc.errors()
+    ]
     return JSONResponse(
         status_code=422,
-        content={"detail": exc.errors(), "body": exc.body},
+        content={"detail": sanitized_errors},
+    )
+
+
+@app.middleware("http")
+async def correlation_id_middleware(request: Request, call_next):
+    correlation_id = request.headers.get("x-request-id") or uuid.uuid4().hex
+    request.state.correlation_id = correlation_id
+    response = await call_next(request)
+    response.headers["X-Request-ID"] = correlation_id
+    csrf_token = request.session.get("csrf_token") if hasattr(request, "session") else None
+    if csrf_token:
+        response.set_cookie(
+            "pytincture_csrf",
+            csrf_token,
+            max_age=AUTH_SESSION_MAX_AGE_SECONDS,
+            secure=AUTH_SESSION_HTTPS_ONLY,
+            httponly=False,
+            samesite=AUTH_SESSION_SAME_SITE,
+        )
+    return response
+
+
+@app.exception_handler(HTTPException)
+async def sanitized_http_exception_handler(request: Request, exc: HTTPException):
+    if exc.status_code >= 500:
+        correlation_id = getattr(request.state, "correlation_id", uuid.uuid4().hex)
+        logger.error(
+            "HTTP failure correlation_id=%s status=%s",
+            correlation_id,
+            exc.status_code,
+            exc_info=exc,
+        )
+        return JSONResponse(
+            {"detail": "Internal server error", "correlation_id": correlation_id},
+            status_code=exc.status_code,
+        )
+    return JSONResponse({"detail": exc.detail}, status_code=exc.status_code, headers=exc.headers)
+
+
+@app.exception_handler(Exception)
+async def sanitized_exception_handler(request: Request, exc: Exception):
+    correlation_id = getattr(request.state, "correlation_id", uuid.uuid4().hex)
+    logger.exception("Unhandled request failure correlation_id=%s", correlation_id)
+    return JSONResponse(
+        {"detail": "Internal server error", "correlation_id": correlation_id},
+        status_code=500,
     )
 
 def get_widgetset(application, static_path):
@@ -258,6 +528,13 @@ def create_pytincture_pkg_in_memory():
     in_memory_zip = io.BytesIO()
     with zipfile.ZipFile(in_memory_zip, 'w', zipfile.ZIP_DEFLATED) as zipf:
         for root, dirs, files in os.walk(pytincture_folder):
+            dirs[:] = [
+                directory
+                for directory in dirs
+                if not directory.startswith(".")
+                and directory
+                not in {"__pycache__", ".venv", "venv", "node_modules", "build", "dist"}
+            ]
             for file in files:
                 file_path = os.path.join(root, file)
                 arcname = os.path.relpath(file_path, os.path.join(pytincture_folder, '..'))
@@ -282,7 +559,7 @@ if allowed_origins:
         allow_headers=allow_all_headers,
     )
 else:
-    print("CORS middleware disabled: set CORS_ALLOWED_ORIGINS to enable cross-origin requests.")
+    logger.info("CORS middleware disabled; set CORS_ALLOWED_ORIGINS to enable it")
 
 from upstash_redis import Redis
 
@@ -339,6 +616,13 @@ class RedisDict:
         # Update local cache with the *decoded* form
         self._cache[key] = value
 
+    def set_with_ttl(self, key, value, ttl_seconds: int):
+        """Set a value that Redis removes automatically after the TTL."""
+        full_key = self._prefix + key
+        serialized = json.dumps(value) if isinstance(value, dict) else str(value)
+        self._redis.set(full_key, serialized, ex=ttl_seconds)
+        self._cache[key] = value
+
     def __delitem__(self, key):
         """Deletes the item from Redis and the local cache. Raises KeyError if missing."""
         full_key = self._prefix + key
@@ -349,6 +633,17 @@ class RedisDict:
         # Also remove from local cache if present
         if key in self._cache:
             del self._cache[key]
+
+    def pop_atomic(self, key, default=None):
+        """Atomically fetch and delete a value, for one-time token consumption."""
+        full_key = self._prefix + key
+        value = self._redis.getdel(full_key)
+        self._cache.pop(key, None)
+        if value is None:
+            return default
+        if isinstance(value, str) and value.startswith("{") and value.endswith("}"):
+            return json.loads(value)
+        return value
 
     def __contains__(self, key):
         """
@@ -459,10 +754,70 @@ if  USE_REDIS_INSTANCE == "true":
         redis_token=REDIS_UPSTASH_INSTANCE_TOKEN,
         key_prefix="session"
     )
+    AUTH_SESSION_REVOCATIONS = RedisDict(
+        redis_url=REDIS_UPSTASH_INSTANCE_URL,
+        redis_token=REDIS_UPSTASH_INSTANCE_TOKEN,
+        key_prefix="revoked-session:",
+    )
+    BFF_REPLAY_TOKEN_STORE = RedisDict(
+        redis_url=REDIS_UPSTASH_INSTANCE_URL,
+        redis_token=REDIS_UPSTASH_INSTANCE_TOKEN,
+        key_prefix="bff-replay-token:",
+    )
 else:
     USER_SESSION_DICT = {}
+    AUTH_SESSION_REVOCATIONS = {}
+    BFF_REPLAY_TOKEN_STORE = {}
 
 MODULE_PATH = get_modules_path()
+
+
+def build_bff_registry(modules_root: Optional[str] = None) -> Dict[tuple[str, str, str], Dict[str, Any]]:
+    """Build the complete exported BFF registry without importing application code."""
+    root_path = os.path.abspath(modules_root or get_modules_path())
+    registry: Dict[tuple[str, str, str], Dict[str, Any]] = {}
+    if not os.path.isdir(root_path):
+        return registry
+    for root, dirs, files in os.walk(root_path):
+        dirs[:] = [
+            directory
+            for directory in dirs
+            if not directory.startswith(".")
+            and directory
+            not in {"__pycache__", ".venv", "venv", "node_modules", "build", "dist"}
+        ]
+        for filename in files:
+            if not filename.endswith(".py") or filename.startswith("."):
+                continue
+            file_path = os.path.join(root, filename)
+            relative_path = os.path.relpath(file_path, root_path).replace(os.sep, "/")
+            try:
+                file_manifest = get_bff_manifest(file_path)
+            except (OSError, SyntaxError, ValueError) as exc:
+                raise RuntimeError(f"Unable to build BFF manifest for {relative_path}") from exc
+            for (class_name, function_name), operation in file_manifest.items():
+                registry[(relative_path, class_name, function_name)] = operation
+    return registry
+
+
+BFF_REGISTRY_ROOT = os.path.abspath(MODULE_PATH)
+BFF_REGISTRY = build_bff_registry(BFF_REGISTRY_ROOT)
+
+
+def reload_bff_registry(modules_root: Optional[str] = None):
+    """Rebuild exported BFF operations, for example after development-time file changes."""
+    global BFF_REGISTRY_ROOT, BFF_REGISTRY
+    BFF_REGISTRY_ROOT = os.path.abspath(modules_root or get_modules_path())
+    BFF_REGISTRY = build_bff_registry(BFF_REGISTRY_ROOT)
+    return BFF_REGISTRY
+
+
+def _registered_bff_operation(
+    modules_root: str, relative_path: str, class_name: str, function_name: str
+) -> Optional[Dict[str, Any]]:
+    if os.path.abspath(modules_root) != BFF_REGISTRY_ROOT:
+        reload_bff_registry(modules_root)
+    return BFF_REGISTRY.get((relative_path.replace(os.sep, "/"), class_name, function_name))
 
 try:
     ALLOWED_NOAUTH_CLASSCALLS = json.loads(os.environ.get("ALLOWED_NOAUTH_CLASSCALLS", "[]"))
@@ -473,10 +828,11 @@ except json.JSONDecodeError as e:
 app.mount("/{application}/frontend", StaticFiles(directory=STATIC_PATH), name="static")
 app.mount("/frontend", StaticFiles(directory=STATIC_PATH), name="static_frontend")
 
-BFF_POLICY_HOOK: Optional[Callable[..., None]] = None
+BFF_POLICY_HOOK: Optional[Callable[..., Any]] = None
+USER_AUTHENTICATOR: Optional[Callable[..., Any]] = None
 
 
-def set_bff_policy_hook(hook: Optional[Callable[..., None]]):
+def set_bff_policy_hook(hook: Optional[Callable[..., Any]]):
     """
     Register (or clear) a global hook that runs before each backend_for_frontend call.
     The hook receives the resolved user session, policy metadata, and request context.
@@ -484,6 +840,167 @@ def set_bff_policy_hook(hook: Optional[Callable[..., None]]):
     global BFF_POLICY_HOOK
     BFF_POLICY_HOOK = hook
     return hook
+
+
+def _configured_bff_policy_hook() -> Optional[Callable[..., Any]]:
+    if BFF_POLICY_HOOK is not None:
+        return BFF_POLICY_HOOK
+    dotted_path = os.getenv("BFF_POLICY_HOOK_PATH", "").strip()
+    if not dotted_path:
+        return None
+    module_name, separator, attribute_name = dotted_path.rpartition(".")
+    if not separator:
+        raise RuntimeError("BFF_POLICY_HOOK_PATH must be a dotted callable path")
+    hook = getattr(importlib.import_module(module_name), attribute_name)
+    if not callable(hook):
+        raise RuntimeError("BFF_POLICY_HOOK_PATH must resolve to a callable")
+    return hook
+
+
+def set_user_authenticator(authenticator: Optional[Callable[..., Any]]):
+    """Register a local email/password authenticator that returns trusted user claims."""
+    global USER_AUTHENTICATOR
+    USER_AUTHENTICATOR = authenticator
+    return authenticator
+
+
+def revoke_session(session_id: str) -> None:
+    """Revoke a signed session; Redis-backed deployments share the revocation."""
+    if session_id:
+        expires_at = time.time() + AUTH_SESSION_MAX_AGE_SECONDS
+        set_with_ttl = getattr(AUTH_SESSION_REVOCATIONS, "set_with_ttl", None)
+        if callable(set_with_ttl):
+            set_with_ttl(session_id, expires_at, AUTH_SESSION_MAX_AGE_SECONDS)
+        else:
+            for revoked_id, revoked_until in tuple(AUTH_SESSION_REVOCATIONS.items()):
+                try:
+                    if float(revoked_until) <= time.time():
+                        del AUTH_SESSION_REVOCATIONS[revoked_id]
+                except (TypeError, ValueError):
+                    continue
+            AUTH_SESSION_REVOCATIONS[session_id] = expires_at
+
+
+def _session_is_revoked(session_id: str) -> bool:
+    expires_at = AUTH_SESSION_REVOCATIONS.get(session_id)
+    if expires_at is None:
+        return False
+    try:
+        if float(expires_at) > time.time():
+            return True
+    except (TypeError, ValueError):
+        return True
+    try:
+        del AUTH_SESSION_REVOCATIONS[session_id]
+    except (KeyError, TypeError):
+        pass
+    return False
+
+
+def _configured_user_authenticator() -> Optional[Callable[..., Any]]:
+    if USER_AUTHENTICATOR is not None:
+        return USER_AUTHENTICATOR
+    dotted_path = os.getenv("AUTH_USER_AUTHENTICATOR", "").strip()
+    if not dotted_path:
+        return None
+    module_name, separator, attribute_name = dotted_path.rpartition(".")
+    if not separator:
+        raise RuntimeError("AUTH_USER_AUTHENTICATOR must be a dotted callable path")
+    authenticator = getattr(importlib.import_module(module_name), attribute_name)
+    if not callable(authenticator):
+        raise RuntimeError("AUTH_USER_AUTHENTICATOR must resolve to a callable")
+    return authenticator
+
+
+def _allowed_email(email: str) -> bool:
+    configured = {
+        value.strip().casefold()
+        for value in os.getenv("ALLOWED_EMAILS", "").split(",")
+        if value.strip()
+    }
+    return not configured or email.casefold() in configured
+
+
+def _is_loopback_development_request(request: Request) -> bool:
+    allowed_hosts = {"localhost", "127.0.0.1", "::1", "testserver"}
+    hostname = (request.url.hostname or "").casefold()
+    forwarded_host = request.headers.get("x-forwarded-host", "").split(",", 1)[0]
+    forwarded_hostname = forwarded_host.rsplit(":", 1)[0].strip("[]").casefold()
+    return hostname in allowed_hosts and (not forwarded_host or forwarded_hostname in allowed_hosts)
+
+
+def _verify_configured_password(email: str, password: str) -> bool:
+    raw_hashes = os.getenv("AUTH_PASSWORD_HASHES", "").strip()
+    if not raw_hashes:
+        return False
+    try:
+        password_hashes = json.loads(raw_hashes)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("AUTH_PASSWORD_HASHES must be a JSON object") from exc
+    if not isinstance(password_hashes, dict):
+        raise RuntimeError("AUTH_PASSWORD_HASHES must be a JSON object")
+    configured_hash = password_hashes.get(email) or password_hashes.get(email.casefold())
+    known_user = isinstance(configured_hash, str)
+    encoded_hash = configured_hash if known_user else (
+        "$argon2id$v=19$m=65536,t=3,p=4$afcNkBX8goR7Ng5icg3p9w$"
+        "UZsHTGXyFb9XrYQnpjpUvFRKKrc3WdWdH8oKTuGhX8M"
+    )
+    try:
+        if encoded_hash.startswith("$argon2id$"):
+            from argon2 import PasswordHasher
+            from argon2.exceptions import VerificationError
+
+            try:
+                verified = PasswordHasher().verify(encoded_hash, password)
+                return known_user and verified
+            except VerificationError:
+                return False
+        if encoded_hash.startswith(("$2a$", "$2b$", "$2y$")):
+            import bcrypt
+
+            verified = bcrypt.checkpw(password.encode("utf-8"), encoded_hash.encode("utf-8"))
+            return known_user and verified
+    except (ValueError, TypeError):
+        return False
+    raise RuntimeError("AUTH_PASSWORD_HASHES values must be Argon2id or bcrypt hashes")
+
+
+async def _authenticate_local_user(
+    request: Request, email: str, password: str
+) -> Dict[str, Any]:
+    if not ENABLE_USER_LOGIN:
+        raise HTTPException(status_code=403, detail="User login not enabled")
+    normalized_email = str(email or "").strip().casefold()
+    if not normalized_email or not isinstance(password, str) or not _allowed_email(normalized_email):
+        raise HTTPException(status_code=401, detail="Invalid email or password")
+
+    authenticator = _configured_user_authenticator()
+    if authenticator is not None:
+        authenticated = authenticator(
+            email=normalized_email, password=password, request=request
+        )
+        if inspect.isawaitable(authenticated):
+            authenticated = await authenticated
+        if not authenticated:
+            raise HTTPException(status_code=401, detail="Invalid email or password")
+        if authenticated is True:
+            return {"email": normalized_email}
+        if not isinstance(authenticated, dict):
+            raise RuntimeError("User authenticator must return a mapping, True, or False")
+        return {**authenticated, "email": normalized_email}
+
+    if _verify_configured_password(normalized_email, password):
+        return {"email": normalized_email}
+
+    if (
+        ENABLE_DEV_EMAIL_LOGIN
+        and os.getenv("ALLOWED_EMAILS", "").strip()
+        and _is_loopback_development_request(request)
+    ):
+        logger.warning("Using loopback-only development email login for %s", normalized_email)
+        return {"email": normalized_email}
+
+    raise HTTPException(status_code=401, detail="Invalid email or password")
 
 
 def _normalize_file_identifier(value: str) -> str:
@@ -556,6 +1073,8 @@ def _coerce_policy_user(user: Any) -> Dict[str, Any]:
 def _clear_auth_session(request: Request) -> None:
     for key in (
         "user",
+        "session_id",
+        "csrf_token",
         "saml_name_id",
         "saml_session_index",
         "saml_provider_id",
@@ -641,6 +1160,8 @@ def _set_authenticated_user(
     session_user = _build_auth_session_user(user_info, **identity_overrides)
     _clear_auth_session(request)
     request.session["user"] = session_user
+    request.session["session_id"] = secrets.token_urlsafe(24)
+    request.session["csrf_token"] = secrets.token_urlsafe(32)
     return session_user
 
 
@@ -669,6 +1190,11 @@ def require_auth(request: Request):
             _clear_auth_session(request)
             return None
 
+        session_id = request.session.get("session_id")
+        if not isinstance(session_id, str) or not session_id or _session_is_revoked(session_id):
+            _clear_auth_session(request)
+            return None
+
         return user_session
     else:
         return {
@@ -680,23 +1206,295 @@ def require_auth(request: Request):
             "is_authenticated": False,
         }
 
+
+def require_authenticated_user(request: Request):
+    user = require_auth(request)
+    if not user:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    return user
+
+
+def _request_origin(request: Request) -> str:
+    scheme = request.headers.get("x-forwarded-proto", request.url.scheme).split(",", 1)[0]
+    host = request.headers.get("x-forwarded-host", request.headers.get("host", "")).split(",", 1)[0]
+    return f"{scheme}://{host}".rstrip("/")
+
+
+def _validate_csrf(request: Request, user: Any) -> None:
+    if request.method in {"GET", "HEAD", "OPTIONS"}:
+        return
+    if not isinstance(user, dict) or user.get("is_authenticated") is not True:
+        return
+    expected = request.session.get("csrf_token", "")
+    supplied = request.headers.get("x-csrf-token", "")
+    if not expected or not supplied or not hmac.compare_digest(str(expected), supplied):
+        raise HTTPException(status_code=403, detail="CSRF validation failed")
+    origin = request.headers.get("origin")
+    if origin and origin.rstrip("/") != _request_origin(request):
+        raise HTTPException(status_code=403, detail="Origin validation failed")
+
+
+def _bff_replay_subject(request: Request, user: Any) -> Optional[str]:
+    if not isinstance(user, dict) or user.get("is_authenticated") is not True:
+        return None
+    session_id = request.session.get("session_id")
+    if not isinstance(session_id, str) or not session_id:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    return session_id
+
+
+def _bff_replay_token_key(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def _purge_expired_bff_replay_tokens() -> None:
+    if not isinstance(BFF_REPLAY_TOKEN_STORE, dict):
+        return
+    now = time.time()
+    for key, value in tuple(BFF_REPLAY_TOKEN_STORE.items()):
+        if not isinstance(value, dict) or float(value.get("expires_at", 0)) <= now:
+            BFF_REPLAY_TOKEN_STORE.pop(key, None)
+
+
+def _store_with_optional_ttl(store, key: str, value: Dict[str, Any], ttl: int) -> None:
+    set_with_ttl = getattr(store, "set_with_ttl", None)
+    if callable(set_with_ttl):
+        set_with_ttl(key, value, ttl)
+    else:
+        store[key] = value
+
+
+def _register_bff_replay_client(request: Request, user: Any) -> Optional[Dict[str, Any]]:
+    if not ENABLE_BFF_REPLAY_TOKENS:
+        return None
+    session_id = _bff_replay_subject(request, user)
+    if session_id is None:
+        return None
+    key = secrets.token_bytes(32)
+    expires_at = time.time() + AUTH_SESSION_MAX_AGE_SECONDS
+    descriptor = json.dumps(
+        {
+            "session_id": session_id,
+            "key": base64.urlsafe_b64encode(key).decode("ascii"),
+            "expires_at": expires_at,
+        },
+        separators=(",", ":"),
+    ).encode("utf-8")
+    capsule_key = hashlib.sha256(
+        SAML_SECRET_KEY.encode("utf-8") + b"pytincture-bff-client-capsule-v1"
+    ).digest()
+    return {"capsule": _encrypt_opaque_envelope(capsule_key, descriptor), "key": key}
+
+
+def _bff_replay_client_key(request: Request, session_id: str) -> bytes:
+    capsule = request.headers.get("x-pytincture-client", "")
+    capsule_key = hashlib.sha256(
+        SAML_SECRET_KEY.encode("utf-8") + b"pytincture-bff-client-capsule-v1"
+    ).digest()
+    try:
+        record = json.loads(_decrypt_opaque_envelope(capsule_key, capsule))
+    except (ValueError, TypeError, json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise HTTPException(status_code=409, detail="Browser state expired") from exc
+    if (
+        not isinstance(record, dict)
+        or record.get("session_id") != session_id
+        or float(record.get("expires_at", 0)) <= time.time()
+    ):
+        raise HTTPException(status_code=409, detail="Browser state expired")
+    try:
+        return base64.urlsafe_b64decode(str(record["key"]).encode("ascii"))
+    except (KeyError, ValueError, TypeError) as exc:
+        raise HTTPException(status_code=409, detail="Browser state expired") from exc
+
+
+def _encrypt_opaque_envelope(key: bytes, plaintext: bytes) -> str:
+    nonce = secrets.token_bytes(16)
+    encrypted = bytearray()
+    for offset in range(0, len(plaintext), 32):
+        counter = (offset // 32).to_bytes(4, "big")
+        stream = hmac.new(key, b"enc" + nonce + counter, hashlib.sha256).digest()
+        encrypted.extend(
+            value ^ stream[index]
+            for index, value in enumerate(plaintext[offset:offset + 32])
+        )
+    ciphertext = bytes(encrypted)
+    tag = hmac.new(key, b"tag" + nonce + ciphertext, hashlib.sha256).digest()[:16]
+    return base64.urlsafe_b64encode(nonce + ciphertext + tag).decode("ascii").rstrip("=")
+
+
+def _decrypt_opaque_envelope(key: bytes, encoded: str) -> bytes:
+    if not encoded:
+        raise ValueError("Missing envelope")
+    padding = "=" * (-len(encoded) % 4)
+    packed = base64.urlsafe_b64decode((encoded + padding).encode("ascii"))
+    if len(packed) < 33:
+        raise ValueError("Invalid envelope")
+    nonce, ciphertext, supplied_tag = packed[:16], packed[16:-16], packed[-16:]
+    expected_tag = hmac.new(
+        key,
+        b"tag" + nonce + ciphertext,
+        hashlib.sha256,
+    ).digest()[:16]
+    if not hmac.compare_digest(supplied_tag, expected_tag):
+        raise ValueError("Invalid envelope")
+    plaintext = bytearray()
+    for offset in range(0, len(ciphertext), 32):
+        counter = (offset // 32).to_bytes(4, "big")
+        stream = hmac.new(key, b"enc" + nonce + counter, hashlib.sha256).digest()
+        plaintext.extend(
+            value ^ stream[index]
+            for index, value in enumerate(ciphertext[offset:offset + 32])
+        )
+    return bytes(plaintext)
+
+
+def _encrypt_bff_replay_payload(key: bytes, tokens: List[str]) -> str:
+    """Return an authenticated opaque envelope for the generated browser stub."""
+    plaintext = json.dumps({"v": 1, "items": tokens}, separators=(",", ":")).encode("utf-8")
+    return _encrypt_opaque_envelope(key, plaintext)
+
+
+def _issue_bff_replay_tokens(session_id: str) -> List[str]:
+    _purge_expired_bff_replay_tokens()
+    expires_at = time.time() + BFF_REPLAY_TOKEN_TTL_SECONDS
+    issued = []
+    for _ in range(BFF_REPLAY_TOKEN_BATCH_SIZE):
+        token = secrets.token_urlsafe(32)
+        value = {"session_id": session_id, "expires_at": expires_at}
+        key = _bff_replay_token_key(token)
+        _store_with_optional_ttl(
+            BFF_REPLAY_TOKEN_STORE,
+            key,
+            value,
+            BFF_REPLAY_TOKEN_TTL_SECONDS,
+        )
+        issued.append(token)
+    return issued
+
+
+def _validate_bff_replay_token(request: Request, user: Any) -> None:
+    if not ENABLE_BFF_REPLAY_TOKENS:
+        return
+    session_id = _bff_replay_subject(request, user)
+    if session_id is None:
+        return
+    supplied = request.headers.get("x-pytincture-bff-token", "")
+    if not supplied:
+        raise HTTPException(
+            status_code=409,
+            detail="BFF request proof invalid or expired",
+            headers={"X-Pytincture-Replay": "rejected"},
+        )
+    key = _bff_replay_token_key(supplied)
+    pop_atomic = getattr(BFF_REPLAY_TOKEN_STORE, "pop_atomic", None)
+    if callable(pop_atomic):
+        token_record = pop_atomic(key, None)
+    else:
+        token_record = BFF_REPLAY_TOKEN_STORE.pop(key, None)
+    if (
+        not isinstance(token_record, dict)
+        or token_record.get("session_id") != session_id
+        or float(token_record.get("expires_at", 0)) <= time.time()
+    ):
+        raise HTTPException(
+            status_code=409,
+            detail="BFF request proof invalid or expired",
+            headers={"X-Pytincture-Replay": "rejected"},
+        )
+
+
+@app.post(
+    "/_pytincture/state",
+    operation_id="issueBffReplayTokens",
+    include_in_schema=False,
+)
+async def issue_bff_replay_tokens(
+    request: Request,
+    user=Depends(require_authenticated_user),
+):
+    if not ENABLE_BFF_REPLAY_TOKENS:
+        raise HTTPException(status_code=404, detail="Not found")
+    _validate_csrf(request, user)
+    session_id = _bff_replay_subject(request, user)
+    if session_id is None:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    client_key = _bff_replay_client_key(request, session_id)
+    payload = _encrypt_bff_replay_payload(
+        client_key,
+        _issue_bff_replay_tokens(session_id),
+    )
+    return Response(
+        content=payload,
+        media_type="application/octet-stream",
+        headers={"Cache-Control": "no-store"},
+    )
+
 @app.get("/{application}/appcode/appcode.pyt", operation_id="downloadAppcodePackage", responses={200: {"description": "StreamingResponse (ZIP file stream, media_type=\"application/zip\")"}, 401: {"description": "HTTPException (if authentication fails when required)"}})
-def download_appcode(request: Request, user=Depends(require_auth)):
+def download_appcode(request: Request, application: str, user=Depends(require_authenticated_user)):
     host = request.headers["host"]
     # Get the protocol from X-Forwarded-Proto header (if set)
     forwarded_proto = request.headers.get("x-forwarded-proto")
     protocol = forwarded_proto or request.url.scheme
-    file_like = create_appcode_pkg_in_memory(host, protocol)
+    replay_client = _register_bff_replay_client(request, user)
+    file_like = create_appcode_pkg_in_memory(
+        host,
+        protocol,
+        application,
+        replay_client=replay_client,
+    )
     return StreamingResponse(
         file_like,
         media_type="application/zip",
         headers={"Content-Disposition": "attachment; filename=appcode.pyt"}
     )
 
-app.mount("/{application}/appcode", StaticFiles(directory=MODULE_PATH), name="static")
+
+_DEFAULT_PUBLIC_ASSET_EXTENSIONS = {
+    ".avif", ".bmp", ".css", ".gif", ".ico", ".jpeg", ".jpg", ".js",
+    ".m4a", ".mp3", ".mp4", ".ogg", ".otf", ".png", ".svg", ".ttf",
+    ".wav", ".webm", ".webmanifest", ".webp", ".woff", ".woff2",
+}
+
+
+def _public_asset_allowed(relative_path: str) -> bool:
+    extension = os.path.splitext(relative_path)[1].lower()
+    if extension in _DEFAULT_PUBLIC_ASSET_EXTENSIONS:
+        return True
+    raw_patterns = os.getenv("PYTINCTURE_PUBLIC_ASSET_PATHS", "").strip()
+    if not raw_patterns:
+        return False
+    try:
+        patterns = json.loads(raw_patterns)
+    except json.JSONDecodeError:
+        patterns = [value.strip() for value in raw_patterns.split(",") if value.strip()]
+    if not isinstance(patterns, list):
+        raise RuntimeError("PYTINCTURE_PUBLIC_ASSET_PATHS must be a list of globs")
+    return any(
+        isinstance(pattern, str) and fnmatch.fnmatch(relative_path, pattern)
+        for pattern in patterns
+    )
+
+
+@app.get("/{application}/appcode/{asset_path:path}", include_in_schema=False)
+async def public_app_asset(application: str, asset_path: str):
+    normalized = asset_path.replace("\\", "/").strip("/")
+    if not normalized or any(part in {"", ".", ".."} or part.startswith(".") for part in normalized.split("/")):
+        raise HTTPException(status_code=404, detail="Asset not found")
+    modules_root = os.path.realpath(get_modules_path())
+    absolute_path = os.path.realpath(os.path.join(modules_root, *normalized.split("/")))
+    try:
+        within_root = os.path.commonpath((modules_root, absolute_path)) == modules_root
+    except ValueError:
+        within_root = False
+    if not within_root or not os.path.isfile(absolute_path) or not _public_asset_allowed(normalized):
+        raise HTTPException(status_code=404, detail="Asset not found")
+    return FileResponse(absolute_path)
 
 @app.get("/classcall/{file_path:path}/{class_name}/{function_name}", operation_id="getClassCall", response_model=Any, responses={200: {"description": "Any (dynamic based on called function return, suggest annotating as Union[Dict, List, str, int, float]) or StreamingResponse for streaming methods"}, 401: {"description": "HTTPException (if not authorized)"}, 404: {"description": "HTTPException (if file not found)"}, 500: {"description": "HTTPException (if function call fails)"}})
 @app.post("/classcall/{file_path:path}/{class_name}/{function_name}", operation_id="postClassCall", response_model=Any, responses={200: {"description": "Any (dynamic based on called function return, suggest annotating as Union[Dict, List, str, int, float]) or StreamingResponse for streaming methods"}, 401: {"description": "HTTPException (if not authorized)"}, 404: {"description": "HTTPException (if file not found)"}, 500: {"description": "HTTPException (if function call fails)"}})
+@app.put("/classcall/{file_path:path}/{class_name}/{function_name}", operation_id="putClassCall", response_model=Any)
+@app.patch("/classcall/{file_path:path}/{class_name}/{function_name}", operation_id="patchClassCall", response_model=Any)
+@app.delete("/classcall/{file_path:path}/{class_name}/{function_name}", operation_id="deleteClassCall", response_model=Any)
 async def class_call(
     file_path: str,
     class_name: str,
@@ -744,7 +1542,38 @@ async def class_call(
 
     if not os.path.isfile(module_file_path):
         raise HTTPException(status_code=404, detail=f"File {request_identifier_with_ext} not found in appcode folder")
-    
+
+    operation = _registered_bff_operation(
+        modules_root,
+        request_identifier_with_ext,
+        class_name,
+        function_name,
+    )
+    if operation is None:
+        raise HTTPException(status_code=404, detail="BFF operation not exported")
+    allowed_methods = tuple(operation["http_methods"])
+    if request.method not in allowed_methods:
+        raise HTTPException(
+            status_code=405,
+            detail="HTTP method not allowed for this BFF operation",
+            headers={"Allow": ", ".join(allowed_methods)},
+        )
+
+    _validate_csrf(request, user)
+    _validate_bff_replay_token(request, user)
+    policy_hook = _configured_bff_policy_hook()
+    if policy_hook:
+        policy_result = policy_hook(
+            user=_coerce_policy_user(user),
+            policy=operation.get("policy", {}),
+            class_name=class_name,
+            function_name=function_name,
+            module_path=request_identifier_with_ext,
+            request=request,
+        )
+        if inspect.isawaitable(policy_result):
+            await policy_result
+
     module = _load_source_module(module_file_path, class_name)
     cls = getattr(module, class_name)
     instance = cls(_user=user)
@@ -760,30 +1589,25 @@ async def class_call(
 
     # 4) If it's a POST, parse JSON body
     data = {}
-    if request.method == "POST":
-        data = await request.json()
+    if request.method in {"POST", "PUT", "PATCH", "DELETE"}:
+        try:
+            data = await request.json()
+        except json.JSONDecodeError as exc:
+            raise HTTPException(status_code=400, detail="Invalid JSON body") from exc
     
-    if type(data) == str:
+    if isinstance(data, str):
         try:
             data = json.loads(str(data))
-        except Exception as e:
-            print("could not convert data to json")
-
-    # 5) Call the function with *args / **kwargs if needed
-    if BFF_POLICY_HOOK:
-        policy_metadata = getattr(function_obj, "_bff_policy", {}) or {}
-        BFF_POLICY_HOOK(
-            user=_coerce_policy_user(user),
-            policy=policy_metadata,
-            class_name=class_name,
-            function_name=function_name,
-            module_path=request_identifier_with_ext,
-            request=request,
-        )
+        except json.JSONDecodeError as exc:
+            raise HTTPException(status_code=400, detail="Invalid JSON body") from exc
 
     if callable(func):
+        if not isinstance(data, dict):
+            raise HTTPException(status_code=400, detail="BFF request body must be an object")
         args = data.get("args", [])
         kwargs = data.get("kwargs", {})
+        if not isinstance(args, list) or not isinstance(kwargs, dict):
+            raise HTTPException(status_code=400, detail="Invalid BFF arguments")
 
         # Handle structured args format if present
         if args and isinstance(args[0], dict) and 'value' in args[0]:
@@ -808,12 +1632,34 @@ async def class_call(
             return data_text
 
         def _sync_iterable(iterable: Iterable, raw: bool = False):
+            started = time.monotonic()
+            output_bytes = 0
             for item in iterable:
-                yield _serialize_stream_item(item, raw)
+                if time.monotonic() - started > BFF_STREAM_MAX_SECONDS:
+                    return
+                serialized = _serialize_stream_item(item, raw)
+                output_bytes += len(serialized.encode("utf-8") if isinstance(serialized, str) else serialized)
+                if output_bytes > BFF_STREAM_MAX_BYTES:
+                    return
+                yield serialized
 
         async def _async_iterable(iterable: AsyncIterable, raw: bool = False):
-            async for item in iterable:
-                yield _serialize_stream_item(item, raw)
+            started = time.monotonic()
+            output_bytes = 0
+            iterator = iterable.__aiter__()
+            while True:
+                remaining = BFF_STREAM_MAX_SECONDS - (time.monotonic() - started)
+                if remaining <= 0:
+                    return
+                try:
+                    item = await asyncio.wait_for(iterator.__anext__(), timeout=remaining)
+                except (StopAsyncIteration, asyncio.TimeoutError):
+                    return
+                serialized = _serialize_stream_item(item, raw)
+                output_bytes += len(serialized.encode("utf-8") if isinstance(serialized, str) else serialized)
+                if output_bytes > BFF_STREAM_MAX_BYTES:
+                    return
+                yield serialized
 
         def _as_streaming_response(result_obj):
             if isinstance(result_obj, StreamingResponse):
@@ -842,15 +1688,30 @@ async def class_call(
             if is_streaming:
                 return _as_streaming_response(result)
             collected_items = []
-            async for item in result:
-                collected_items.append(item)
+            async def collect_items():
+                async for item in result:
+                    collected_items.append(item)
+            try:
+                await asyncio.wait_for(collect_items(), timeout=BFF_CALL_TIMEOUT_SECONDS)
+            except asyncio.TimeoutError as exc:
+                raise HTTPException(status_code=504, detail="BFF call timed out") from exc
             return collected_items
 
         if is_coroutine_function:
-            result = await func(*args, **kwargs)
+            try:
+                result = await asyncio.wait_for(
+                    func(*args, **kwargs), timeout=BFF_CALL_TIMEOUT_SECONDS
+                )
+            except asyncio.TimeoutError as exc:
+                raise HTTPException(status_code=504, detail="BFF call timed out") from exc
         else:
-            print(args, kwargs)
-            result = func(*args, **kwargs)
+            try:
+                result = await asyncio.wait_for(
+                    run_in_threadpool(func, *args, **kwargs),
+                    timeout=BFF_CALL_TIMEOUT_SECONDS,
+                )
+            except asyncio.TimeoutError as exc:
+                raise HTTPException(status_code=504, detail="BFF call timed out") from exc
 
         if is_streaming:
             return _as_streaming_response(result)
@@ -860,9 +1721,14 @@ async def class_call(
     return func
 
 @app.post("/logs", operation_id="postLogs", responses={200: {"description": "JSONResponse ({\"status\": \"ok\"})"}, 401: {"description": "HTTPException (if authentication fails)"}})
-async def logs_endpoint(request: Request, user=Depends(require_auth)):
+async def logs_endpoint(request: Request, user=Depends(require_authenticated_user)):
+    _validate_csrf(request, user)
     data = await request.json()
-    print(data)
+    logger.info(
+        "Browser log received correlation_id=%s keys=%s",
+        getattr(request.state, "correlation_id", ""),
+        sorted(data) if isinstance(data, dict) else [],
+    )
     return {"status": "ok"}
 
 
@@ -874,24 +1740,93 @@ ENABLE_GOOGLE_AUTH = os.getenv("ENABLE_GOOGLE_AUTH", "false").lower() == "true"
 ENABLE_USER_LOGIN = os.getenv("ENABLE_USER_LOGIN", "false").lower() == "true"
 ENABLE_SAML_AUTH = os.getenv("ENABLE_SAML_AUTH", "false").lower() == "true"
 ENABLE_MICROSOFT_AUTH = os.getenv("ENABLE_MICROSOFT_AUTH", "false").lower() == "true"
+ENABLE_DEV_EMAIL_LOGIN = os.getenv("ENABLE_DEV_EMAIL_LOGIN", "false").lower() == "true"
+DEV_EMAIL_LOGIN_ONLY = bool(
+    ENABLE_DEV_EMAIL_LOGIN
+    and ENABLE_USER_LOGIN
+    and not (ENABLE_GOOGLE_AUTH or ENABLE_MICROSOFT_AUTH or ENABLE_SAML_AUTH)
+)
+
+
+def _authentication_enabled() -> bool:
+    return bool(
+        ENABLE_GOOGLE_AUTH
+        or ENABLE_MICROSOFT_AUTH
+        or ENABLE_USER_LOGIN
+        or ENABLE_SAML_AUTH
+    )
 
 _configured_saml_secret = os.getenv("SAML_SECRET_KEY", "").strip()
-if _configured_saml_secret and len(_configured_saml_secret) < 32:
-    raise RuntimeError("SAML_SECRET_KEY must contain at least 32 characters")
+_configured_legacy_secret = os.getenv("SECRET_KEY", "").strip()
+SAML_SECRET_KEY = _configured_saml_secret or _configured_legacy_secret
+if _authentication_enabled():
+    if (
+        not SAML_SECRET_KEY
+        and ENABLE_DEV_EMAIL_LOGIN
+        and DEV_EMAIL_LOGIN_ONLY
+    ):
+        SAML_SECRET_KEY = secrets.token_urlsafe(32)
+        logger.warning(
+            "Generated an ephemeral development session key; sessions will reset on restart"
+        )
+    elif len(SAML_SECRET_KEY) < 32 or len(set(SAML_SECRET_KEY)) < 8:
+        raise RuntimeError(
+            "Authentication requires SAML_SECRET_KEY with at least 32 random characters; "
+            "generate one with `python -c \"import secrets; print(secrets.token_urlsafe(32))\"`"
+        )
+else:
+    # An unauthenticated development service still gets an unpredictable cookie signer.
+    SAML_SECRET_KEY = SAML_SECRET_KEY or secrets.token_urlsafe(32)
 
-SAML_SECRET_KEY = (
-    _configured_saml_secret
-    or os.getenv("SECRET_KEY", "").strip()
-    or "verysecretkey"
-)
-AUTH_SESSION_SCHEMA_VERSION = 1
+_previous_secret_value = os.getenv("AUTH_SESSION_PREVIOUS_SECRET_KEYS", "").strip()
+if _previous_secret_value:
+    try:
+        AUTH_SESSION_PREVIOUS_SECRET_KEYS = json.loads(_previous_secret_value)
+    except json.JSONDecodeError:
+        AUTH_SESSION_PREVIOUS_SECRET_KEYS = [
+            value.strip() for value in _previous_secret_value.split(",") if value.strip()
+        ]
+    if not isinstance(AUTH_SESSION_PREVIOUS_SECRET_KEYS, list) or any(
+        not isinstance(value, str) or len(value) < 32
+        for value in AUTH_SESSION_PREVIOUS_SECRET_KEYS
+    ):
+        raise RuntimeError("AUTH_SESSION_PREVIOUS_SECRET_KEYS must contain strong keys")
+else:
+    AUTH_SESSION_PREVIOUS_SECRET_KEYS = []
+
+AUTH_SESSION_SCHEMA_VERSION = 2
 AUTH_SESSION_MAX_AGE_SECONDS = int(os.getenv("AUTH_SESSION_MAX_AGE_SECONDS", "28800"))
 if AUTH_SESSION_MAX_AGE_SECONDS <= 0:
     raise RuntimeError("AUTH_SESSION_MAX_AGE_SECONDS must be greater than zero")
 AUTH_SESSION_HTTPS_ONLY = os.getenv(
     "AUTH_SESSION_HTTPS_ONLY",
-    "true" if _configured_saml_secret else "false",
+    "false" if DEV_EMAIL_LOGIN_ONLY else "true",
 ).lower() == "true"
+AUTH_SESSION_SAME_SITE = os.getenv("AUTH_SESSION_SAME_SITE", "lax").lower()
+if AUTH_SESSION_SAME_SITE not in {"lax", "strict", "none"}:
+    raise RuntimeError("AUTH_SESSION_SAME_SITE must be lax, strict, or none")
+MAX_REQUEST_BODY_BYTES = int(os.getenv("MAX_REQUEST_BODY_BYTES", str(2 * 1024 * 1024)))
+if MAX_REQUEST_BODY_BYTES <= 0:
+    raise RuntimeError("MAX_REQUEST_BODY_BYTES must be greater than zero")
+BFF_CALL_TIMEOUT_SECONDS = float(os.getenv("BFF_CALL_TIMEOUT_SECONDS", "30"))
+BFF_STREAM_MAX_SECONDS = float(os.getenv("BFF_STREAM_MAX_SECONDS", "300"))
+BFF_STREAM_MAX_BYTES = int(os.getenv("BFF_STREAM_MAX_BYTES", str(10 * 1024 * 1024)))
+if BFF_CALL_TIMEOUT_SECONDS <= 0 or BFF_STREAM_MAX_SECONDS <= 0 or BFF_STREAM_MAX_BYTES <= 0:
+    raise RuntimeError("BFF timeout and stream limits must be greater than zero")
+ENABLE_BFF_REPLAY_TOKENS = os.getenv("ENABLE_BFF_REPLAY_TOKENS", "false").lower() == "true"
+BFF_REPLAY_TOKEN_BATCH_SIZE = int(os.getenv("BFF_REPLAY_TOKEN_BATCH_SIZE", "12"))
+BFF_REPLAY_TOKEN_LOW_WATERMARK = int(os.getenv("BFF_REPLAY_TOKEN_LOW_WATERMARK", "3"))
+BFF_REPLAY_TOKEN_TTL_SECONDS = int(os.getenv("BFF_REPLAY_TOKEN_TTL_SECONDS", "300"))
+if not 1 <= BFF_REPLAY_TOKEN_BATCH_SIZE <= 100:
+    raise RuntimeError("BFF_REPLAY_TOKEN_BATCH_SIZE must be between 1 and 100")
+if not 0 <= BFF_REPLAY_TOKEN_LOW_WATERMARK < BFF_REPLAY_TOKEN_BATCH_SIZE:
+    raise RuntimeError(
+        "BFF_REPLAY_TOKEN_LOW_WATERMARK must be non-negative and below the batch size"
+    )
+if not 10 <= BFF_REPLAY_TOKEN_TTL_SECONDS <= AUTH_SESSION_MAX_AGE_SECONDS:
+    raise RuntimeError(
+        "BFF_REPLAY_TOKEN_TTL_SECONDS must be between 10 seconds and the session maximum age"
+    )
 
 config_data = {
     "GOOGLE_CLIENT_ID": os.getenv("GOOGLE_CLIENT_ID", ""),
@@ -1163,7 +2098,7 @@ def _certificate_fingerprint(value: str) -> Optional[str]:
     try:
         der = base64.b64decode(body)
     except Exception as exc:
-        print(f"DEBUG: Failed to decode certificate for fingerprint: {exc}")
+        logger.debug("Failed to decode certificate for fingerprint", exc_info=exc)
         return None
     return hashlib.sha1(der).hexdigest()
 
@@ -1182,7 +2117,7 @@ def _extract_response_certificates(xml_payload: str) -> List[str]:
             if (node.text or "").strip()
         ]
     except Exception as exc:
-        print(f"DEBUG: Failed to parse SAML XML for embedded certificates: {exc}")
+        logger.debug("Failed to parse SAML XML certificates", exc_info=exc)
         return []
 
 
@@ -1259,22 +2194,15 @@ def _debug_session_state(stage: str, request: Request) -> None:
         cookie_present = cookie_value is not None
         cookie_length = len(cookie_value) if cookie_present else 0
         session_keys = list(request.session.keys())
-        tracked_snapshot = {
-            key: request.session.get(key)
-            for key in (
-                "saml_request_id",
-                "return_to",
-                "saml_name_id",
-                "saml_session_index",
-            )
-        }
-        print(
-            f"DEBUG: Session state ({stage}) -> "
-            f"cookie_present={cookie_present} size={cookie_length} "
-            f"keys={session_keys} tracked_values={tracked_snapshot}"
+        logger.debug(
+            "SAML session stage=%s cookie_present=%s cookie_size=%s keys=%s",
+            stage,
+            cookie_present,
+            cookie_length,
+            session_keys,
         )
     except Exception as exc:  # pragma: no cover - diagnostics only
-        print(f"DEBUG: Failed to inspect session during {stage}: {exc}")
+        logger.debug("Unable to inspect SAML session stage=%s", stage, exc_info=exc)
 
 
 def _build_saml_settings(request: Request, application: str, provider: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
@@ -1464,12 +2392,14 @@ else:
 
 # Add session middleware (needed to store "return_to" and user info)
 app.add_middleware(
-    SessionMiddleware,
+    RotatingSessionMiddleware,
     secret_key=SAML_SECRET_KEY,
+    previous_secret_keys=AUTH_SESSION_PREVIOUS_SECRET_KEYS,
     max_age=AUTH_SESSION_MAX_AGE_SECONDS,
-    same_site="lax",
+    same_site=AUTH_SESSION_SAME_SITE,
     https_only=AUTH_SESSION_HTTPS_ONLY,
 )
+app.add_middleware(RequestBodyLimitMiddleware, max_bytes=MAX_REQUEST_BODY_BYTES)
 
 # ================
 # SAML SSO SETUP
@@ -1517,19 +2447,13 @@ async def _saml_login(request: Request, application: str, provider_id: Optional[
     safe_return_to = _sanitize_return_to(return_to)
     if safe_return_to:
         request.session["return_to"] = safe_return_to
-        print(f"DEBUG: Stored return_to '{safe_return_to}' in session for application '{application}'")
-    else:
-        if return_to:
-            print(f"DEBUG: Ignored unsafe return_to '{return_to}'")
-        else:
-            print("DEBUG: No return_to param supplied")
 
     try:
         saml_auth = _init_saml_auth(request, application, provider=provider)
     except RuntimeError as config_error:
-        raise HTTPException(status_code=500, detail=str(config_error)) from config_error
+        raise HTTPException(status_code=500, detail="SAML configuration error") from config_error
     except Exception as exc:  # noqa: BLE001
-        raise HTTPException(status_code=500, detail=f"SAML initialization failed: {exc}") from exc
+        raise HTTPException(status_code=500, detail="SAML initialization failed") from exc
 
     session_return_to = _sanitize_return_to(request.session.pop("return_to", None))
     fallback_return = safe_return_to or session_return_to
@@ -1605,111 +2529,38 @@ async def _saml_assertion_consumer(request: Request, application: str, provider_
     if provider["id"] != state_provider_id:
         raise HTTPException(status_code=400, detail="SAML provider mismatch")
     
-    # DEBUG: Log what we received
-    print(f"DEBUG: Received form data keys: {list(post_data.keys())}")
-    if 'SAMLResponse' in post_data:
-        try:
-            decoded_response = base64.b64decode(post_data['SAMLResponse']).decode('utf-8')
-            print(f"DEBUG: SAML Response (first 500 chars): {decoded_response[:500]}...")
-            embedded_certs = _extract_response_certificates(decoded_response)
-            if embedded_certs:
-                for idx, embedded_cert in enumerate(embedded_certs):
-                    fingerprint = _certificate_fingerprint(embedded_cert)
-                    preview = embedded_cert[:80]
-                    print(
-                        f"DEBUG: Embedded certificate #{idx} fingerprint={fingerprint} "
-                        f"preview={preview}..."
-                    )
-                    print(f"DEBUG: Embedded certificate #{idx} full={embedded_cert}")
-            else:
-                print("DEBUG: No embedded certificates found inside SAML response XML")
-        except Exception as e:
-            print(f"DEBUG: Could not decode SAML response: {e}")
-
     try:
         saml_auth = _init_saml_auth(request, application, provider=provider, post_data=post_data)
-        
-        # DEBUG: Log SAML settings  
-        settings = saml_auth.get_settings()
-        sp_data = settings.get_sp_data()
-        idp_data = settings.get_idp_data()
-        
-        print(f"DEBUG: SP Entity ID: {sp_data.get('entityId')}")
-        print(f"DEBUG: SP ACS URL: {sp_data.get('assertionConsumerService', {}).get('url')}")
-        print(f"DEBUG: IdP Entity ID: {idp_data.get('entityId')}")
-        print(f"DEBUG: IdP SSO URL: {idp_data.get('singleSignOnService', {}).get('url')}")
-        
-        # DEBUG: Check certificate
-        idp_cert = idp_data.get('x509cert', '')
-        print(f"DEBUG: IdP Certificate (first 100 chars): {idp_cert[:100]}...")
-        env_fingerprint = _certificate_fingerprint(idp_cert)
-        print(f"DEBUG: IdP Certificate fingerprint (env): {env_fingerprint}")
-        
         request_id = relay_state["request_id"]
         request.session.pop("saml_request_id", None)
         request.session.pop("saml_provider_id", None)
-        
-        # Process the SAML response
         try:
             saml_auth.process_response(request_id=request_id)
         except OneLogin_Saml2_ValidationError as validation_error:
-            print(
-                "DEBUG: OneLogin validation error encountered during process_response "
-                f"(code={validation_error.code}): {validation_error.message}"
+            logger.warning(
+                "SAML response validation failed correlation_id=%s code=%s",
+                getattr(request.state, "correlation_id", ""),
+                validation_error.code,
             )
-            import traceback
-            traceback.print_exc()
             raise
-        
-        # DEBUG: Get detailed error information
-        errors = saml_auth.get_errors()
-        print(f"DEBUG: SAML Errors: {errors}")
-        print(f"DEBUG: SAML Last Error Reason: {saml_auth.get_last_error_reason()}")
-        print(f"DEBUG: SAML Is Authenticated: {saml_auth.is_authenticated()}")
-        
-        try:
-            print(f"DEBUG: SAML Name ID: {saml_auth.get_nameid()}")
-        except:
-            print("DEBUG: Could not get Name ID")
-        
-        # DEBUG: Check what attributes we got
-        try:
-            attributes = saml_auth.get_attributes()
-            print(f"DEBUG: SAML Attributes: {attributes}")
-        except:
-            print("DEBUG: Could not get attributes")
-        
     except RuntimeError as config_error:
-        print(f"DEBUG: Runtime error: {config_error}")
-        raise HTTPException(status_code=500, detail=str(config_error)) from config_error
+        raise HTTPException(status_code=500, detail="SAML configuration error") from config_error
     except Exception as exc:  # noqa: BLE001
-        print(f"DEBUG: General exception: {exc}")
-        import traceback
-        traceback.print_exc()
-        raise HTTPException(status_code=400, detail=f"Failed to process SAML response: {exc}") from exc
+        raise HTTPException(status_code=400, detail="Invalid SAML response") from exc
 
     errors = saml_auth.get_errors()
     if errors:
-        # DEBUG: More detailed error logging
-        print(f"DEBUG: Detailed SAML errors before raising exception: {errors}")
-        print(f"DEBUG: SAML last error reason: {saml_auth.get_last_error_reason()}")
-        
-        # Check for specific signature validation errors
-        if any('signature' in str(error).lower() for error in errors):
-            print("DEBUG: Signature validation error detected")
-            settings = saml_auth.get_settings()
-            idp_data = settings.get_idp_data()
-            cert = idp_data.get('x509cert', '')
-            print(f"DEBUG: Certificate being used: {cert[:200]}...")
-        
-        raise HTTPException(status_code=400, detail=f"SAML response contained errors: {errors}")
+        logger.warning(
+            "SAML response rejected correlation_id=%s error_codes=%s",
+            getattr(request.state, "correlation_id", ""),
+            errors,
+        )
+        raise HTTPException(status_code=400, detail="Invalid SAML response")
 
     if not saml_auth.is_authenticated():
-        print("DEBUG: SAML authentication failed - user not authenticated")
         raise HTTPException(status_code=401, detail="SAML authentication failed")
 
     attributes = saml_auth.get_attributes()
-    print(f"DEBUG: Final attributes received: {attributes}")
     
     email_candidate_keys = [
         key for key in [
@@ -1732,13 +2583,10 @@ async def _saml_assertion_consumer(request: Request, application: str, provider_
     if not email_attr:
         email_attr = saml_auth.get_nameid()
 
-    print(f"DEBUG: Email attribute extracted: {email_attr}")
-    
     if not email_attr:
         raise HTTPException(status_code=400, detail="SAML response missing required email attribute")
 
     name_attr = _get_saml_attribute(attributes, SAML_NAME_ATTRIBUTE) if SAML_NAME_ATTRIBUTE else None
-    print(f"DEBUG: Name attribute extracted: {name_attr}")
 
     # Normalize attributes so they are JSON serializable for session storage.
     normalized_attributes: Dict[str, List[str]] = {
@@ -1758,14 +2606,8 @@ async def _saml_assertion_consumer(request: Request, application: str, provider_
 
     if allowed_roles:
         flattened_roles = set(session_roles)
-        print(f"DEBUG: Candidate role values from attributes: {flattened_roles}")
         has_allowed_role = any(role in flattened_roles for role in allowed_roles)
         if not has_allowed_role:
-            print(
-                f"DEBUG: User missing required SAML role. "
-                f"Allowed roles={allowed_roles} "
-                f"searched_keys={role_attribute_keys}"
-            )
             raise HTTPException(status_code=401, detail="Not authorized for this application")
 
     user_info = {
@@ -1785,8 +2627,6 @@ async def _saml_assertion_consumer(request: Request, application: str, provider_
 
     if os.getenv("ALLOWED_EMAILS", "") != "":
         allowed_emails = [email.strip().lower() for email in os.getenv("ALLOWED_EMAILS", "").split(",") if email.strip()]
-        print(f"DEBUG: Allowed emails: {allowed_emails}")
-        print(f"DEBUG: User email: {email_attr.lower()}")
         if email_attr.lower() not in allowed_emails:
             raise HTTPException(status_code=401, detail="Not authorized")
 
@@ -1794,15 +2634,9 @@ async def _saml_assertion_consumer(request: Request, application: str, provider_
 
     cached_redirect = _sanitize_return_to(relay_state.get("return_to"))
     session_redirect = _sanitize_return_to(request.session.pop("return_to", None))
-    if cached_redirect:
-        print(f"DEBUG: Using return_to from RelayState: {cached_redirect}")
     if not cached_redirect:
         cached_redirect = session_redirect
-        if cached_redirect:
-            print(f"DEBUG: Using return_to from session: {cached_redirect}")
     redirect_target = cached_redirect or _get_saml_default_redirect(application, request, provider=provider)
-    
-    print(f"DEBUG: Redirecting to: {redirect_target}")
     return RedirectResponse(url=redirect_target, status_code=302)
 
 
@@ -1848,11 +2682,11 @@ async def _saml_metadata(request: Request, application: str, provider_id: Option
             allowed_errors = {"sp_acs_url_invalid", "sp_entity_id_invalid"}
             remaining_errors = [err for err in errors if err not in allowed_errors]
             if remaining_errors:
-                raise HTTPException(status_code=500, detail=f"SAML metadata validation errors: {remaining_errors}")
+                raise HTTPException(status_code=500, detail="SAML metadata validation failed")
     except RuntimeError as config_error:
-        raise HTTPException(status_code=500, detail=str(config_error)) from config_error
+        raise HTTPException(status_code=500, detail="SAML configuration error") from config_error
     except Exception as exc:  # noqa: BLE001
-        raise HTTPException(status_code=500, detail=f"Failed to generate SAML metadata: {exc}") from exc
+        raise HTTPException(status_code=500, detail="Failed to generate SAML metadata") from exc
 
     return Response(content=metadata_xml, media_type="application/xml")
 
@@ -1878,7 +2712,8 @@ async def auth_google_callback(request: Request, application: str):
     try:
         token = await oauth.google.authorize_access_token(request)
     except OAuthError as e:
-        return JSONResponse({"error": str(e)}, status_code=401)
+        logger.info("Google OAuth callback rejected", exc_info=e)
+        return JSONResponse({"error": "Authentication failed"}, status_code=401)
     
     user_info = token.get("userinfo") or {}
     if not user_info:
@@ -1932,7 +2767,8 @@ async def auth_microsoft_callback(request: Request, application: str):
     try:
         token = await oauth.microsoft.authorize_access_token(request)
     except OAuthError as e:
-        return JSONResponse({"error": str(e)}, status_code=401)
+        logger.info("Microsoft OAuth callback rejected", exc_info=e)
+        return JSONResponse({"error": "Authentication failed"}, status_code=401)
 
     user_info = token.get("userinfo") or {}
     if not user_info:
@@ -1962,13 +2798,15 @@ def logout(request: Request,  application: str):
     """
     Logs the user out of *your app only*.
     """
-    # 1) Clear user info from session
+    revoke_session(str(request.session.get("session_id") or ""))
     _clear_auth_session(request)
     # 2) If stored tokens in session, remove them
     # request.session.pop("token", None)
 
     # 3) Redirect anywhere in *your* app after local logout
-    return RedirectResponse(url=f"/{application}/login", status_code=302)
+    response = RedirectResponse(url=f"/{application}/login", status_code=302)
+    response.delete_cookie("pytincture_csrf")
+    return response
 
 # ======================
 # LOGIN PAGE
@@ -2150,21 +2988,16 @@ async def auth_user_callback(request: Request, application: str):
     """
 
     form = await request.form()
-    email = form.get('email')
-    password = form.get('password')
+    email = str(form.get('email') or "")
+    password = str(form.get('password') or "")
+    authenticated_claims = await _authenticate_local_user(request, email, password)
 
     user_info = {
-        "email": email,
+        **authenticated_claims,
         "picture": f"{application}/appcode/profile.png",
         "auth_type": "user",
-        "roles": [],
+        "roles": authenticated_claims.get("roles", []),
     }
-
-    # You can optionally grab user info from token["userinfo"]
-    if os.getenv("ALLOWED_EMAILS", "") != "":
-        allowed_emails = os.getenv("ALLOWED_EMAILS").split(",")  # Assuming comma-separated
-        if user_info.get("email", "").lower() not in [email.strip().lower() for email in allowed_emails]:
-            return JSONResponse({"error": "Not authorized"}, status_code=401)
 
     _set_authenticated_user(request, user_info)
 
@@ -2182,20 +3015,15 @@ async def mcp_auth(request: Request, application: str, auth_input: MCPAuthInput 
     """
     MCP-specific authentication endpoint. Authenticates with email and password via JSON, sets session, and returns status. The response includes Set-Cookie header for session, which can be used in subsequent calls.
     """
-    if not ENABLE_USER_LOGIN:
-        raise HTTPException(status_code=403, detail="User login not enabled")
-
+    authenticated_claims = await _authenticate_local_user(
+        request, auth_input.email, auth_input.password
+    )
     user_info = {
-        "email": auth_input.email,
+        **authenticated_claims,
         "picture": f"{application}/appcode/profile.png",
         "auth_type": "user",
-        "roles": [],
+        "roles": authenticated_claims.get("roles", []),
     }
-
-    if os.getenv("ALLOWED_EMAILS", "") != "":
-        allowed_emails = os.getenv("ALLOWED_EMAILS").split(",")  # Assuming comma-separated
-        if user_info.get("email", "").lower() not in [email.strip().lower() for email in allowed_emails]:
-            raise HTTPException(status_code=401, detail="Not authorized")
 
     _set_authenticated_user(request, user_info)
 
@@ -2286,7 +3114,7 @@ def find_main_window_subclass(file_path):
         
         return None  # No MainWindow subclass found
     except Exception as e:
-        print(f"Error finding MainWindow subclass: {e}")
+        logger.warning("Unable to find MainWindow subclass", exc_info=e)
         return None
 
 def _find_app_string_setting(file_path, assignment_names, config_keys):
@@ -2298,7 +3126,7 @@ def _find_app_string_setting(file_path, assignment_names, config_keys):
             source = f.read()
         tree = ast.parse(source)
     except Exception as e:
-        print(f"Error reading app configuration: {e}")
+        logger.warning("Unable to read app configuration", exc_info=e)
         return None
 
     def extract_string(node):

--- a/pytincture/dataclass.py
+++ b/pytincture/dataclass.py
@@ -129,6 +129,150 @@ def bff_policy(**metadata):
     return _apply
 
 
+def bff_http_methods(*methods: str):
+    """Declare the HTTP methods permitted for a BFF operation.
+
+    BFF methods default to POST. GET is intended only for side-effect-free
+    operations; PUT, PATCH, and DELETE are also supported for explicit APIs.
+    """
+    normalized = tuple(dict.fromkeys(str(method).upper() for method in methods))
+    supported = {"GET", "POST", "PUT", "PATCH", "DELETE"}
+    if not normalized or any(method not in supported for method in normalized):
+        raise ValueError(
+            "bff_http_methods requires one or more of GET, POST, PUT, PATCH, DELETE"
+        )
+
+    def _apply(target):
+        setattr(target, "_bff_http_methods", normalized)
+        return target
+
+    return _apply
+
+
+def _literal_keyword_metadata(
+    decorators: list[ast.expr],
+    *,
+    decorator_name: str,
+    import_aliases: Set[str],
+    module_aliases: Set[str],
+) -> Dict[str, Any]:
+    metadata: Dict[str, Any] = {}
+    for decorator in decorators:
+        matches, decorator_node = _decorator_matches(
+            decorator,
+            decorator_name=decorator_name,
+            import_aliases=import_aliases,
+            module_aliases=module_aliases,
+        )
+        if not matches or not isinstance(decorator_node, ast.Call):
+            continue
+        for keyword in decorator_node.keywords:
+            if keyword.arg is None:
+                raise ValueError(
+                    f"{decorator_name} does not support **kwargs in the static BFF manifest"
+                )
+            try:
+                metadata[keyword.arg] = ast.literal_eval(keyword.value)
+            except (ValueError, TypeError) as exc:
+                raise ValueError(
+                    f"{decorator_name} metadata must use literal values so policy can run before import"
+                ) from exc
+    return metadata
+
+
+def _declared_http_methods(
+    decorators: list[ast.expr],
+    *,
+    import_aliases: Set[str],
+    module_aliases: Set[str],
+) -> tuple[str, ...]:
+    for decorator in decorators:
+        matches, decorator_node = _decorator_matches(
+            decorator,
+            decorator_name="bff_http_methods",
+            import_aliases=import_aliases,
+            module_aliases=module_aliases,
+        )
+        if not matches:
+            continue
+        if not isinstance(decorator_node, ast.Call):
+            raise ValueError("bff_http_methods must be called with explicit HTTP methods")
+        try:
+            methods = tuple(
+                dict.fromkeys(str(ast.literal_eval(argument)).upper() for argument in decorator_node.args)
+            )
+        except (ValueError, TypeError) as exc:
+            raise ValueError("bff_http_methods values must be string literals") from exc
+        supported = {"GET", "POST", "PUT", "PATCH", "DELETE"}
+        if not methods or any(method not in supported for method in methods):
+            raise ValueError(
+                "bff_http_methods requires one or more of GET, POST, PUT, PATCH, DELETE"
+            )
+        return methods
+    return ("POST",)
+
+
+def get_bff_manifest(file_path: str) -> Dict[tuple[str, str], Dict[str, Any]]:
+    """Statically discover exported BFF operations without importing app code."""
+    with open(file_path, "r", encoding="utf-8") as source_file:
+        module = ast.parse(source_file.read(), filename=file_path)
+
+    module_aliases = _collect_module_aliases(module)
+    bff_aliases = _collect_import_aliases(module, "backend_for_frontend")
+    policy_aliases = _collect_import_aliases(module, "bff_policy")
+    method_aliases = _collect_import_aliases(module, "bff_http_methods")
+    manifest: Dict[tuple[str, str], Dict[str, Any]] = {}
+
+    for class_node in (node for node in module.body if isinstance(node, ast.ClassDef)):
+        is_exported = any(
+            _decorator_matches(
+                decorator,
+                decorator_name="backend_for_frontend",
+                import_aliases=bff_aliases,
+                module_aliases=module_aliases,
+            )[0]
+            for decorator in class_node.decorator_list
+        )
+        if not is_exported:
+            continue
+
+        class_policy = _literal_keyword_metadata(
+            class_node.decorator_list,
+            decorator_name="bff_policy",
+            import_aliases=policy_aliases,
+            module_aliases=module_aliases,
+        )
+        for member in class_node.body:
+            if isinstance(member, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                if member.name.startswith("_"):
+                    continue
+                method_policy = _literal_keyword_metadata(
+                    member.decorator_list,
+                    decorator_name="bff_policy",
+                    import_aliases=policy_aliases,
+                    module_aliases=module_aliases,
+                )
+                manifest[(class_node.name, member.name)] = {
+                    "policy": {**class_policy, **method_policy},
+                    "http_methods": _declared_http_methods(
+                        member.decorator_list,
+                        import_aliases=method_aliases,
+                        module_aliases=module_aliases,
+                    ),
+                    "kind": "method",
+                }
+            elif isinstance(member, (ast.Assign, ast.AnnAssign)):
+                targets = member.targets if isinstance(member, ast.Assign) else [member.target]
+                for target in targets:
+                    if isinstance(target, ast.Name) and not target.id.startswith("_"):
+                        manifest[(class_node.name, target.id)] = {
+                            "policy": dict(class_policy),
+                            "http_methods": ("GET",),
+                            "kind": "attribute",
+                        }
+    return manifest
+
+
 def _constructor_accepts_user_argument(cls) -> Optional[inspect.Parameter]:
     init_method = cls.__dict__.get("__init__")
     if init_method is None or init_method is object.__init__:
@@ -208,6 +352,7 @@ def backend_for_frontend(cls):
             streaming_enabled = getattr(method, "_bff_streaming", False)
             streaming_raw = getattr(method, "_bff_streaming_raw", False)
             streaming_media_type = getattr(method, "_bff_streaming_media_type", "text/event-stream")
+            declared_http_methods = getattr(method, "_bff_http_methods", ("POST",))
 
             # Create list of parameters in order (excluding self)
             param_list = [
@@ -279,6 +424,7 @@ def backend_for_frontend(cls):
                 },
                 'responses': responses_spec
             }
+            operation_spec['x-bff-http-methods'] = list(declared_http_methods)
 
             if streaming_enabled:
                 operation_spec['x-bff-streaming'] = True
@@ -333,6 +479,13 @@ def backend_for_frontend(cls):
 
         def __getattr__(self, item):
             return getattr(self._real_instance, item)
+
+    BackendForFrontendWrapper.__name__ = cls.__name__
+    BackendForFrontendWrapper.__qualname__ = cls.__qualname__
+    BackendForFrontendWrapper.__module__ = cls.__module__
+    BackendForFrontendWrapper.__doc__ = cls.__doc__
+    BackendForFrontendWrapper._pytincture_bff_export = True
+    BackendForFrontendWrapper._pytincture_bff_original = cls
 
     return BackendForFrontendWrapper
     
@@ -446,7 +599,7 @@ def get_imports_used_in_class(file_path, class_name):
 
     return import_lines, imports_used
 
-def generate_stub_classes(file_path, return_url, return_protocol):
+def generate_stub_classes(file_path, return_url, return_protocol, replay_client=None):
     with open(file_path, 'r') as file:
         code = file.read()
     
@@ -454,8 +607,14 @@ def generate_stub_classes(file_path, return_url, return_protocol):
     module = ast.parse(code)
     backend_for_frontend_aliases = _collect_import_aliases(module, "backend_for_frontend")
     bff_stream_aliases = _collect_import_aliases(module, "bff_stream")
+    bff_http_method_aliases = _collect_import_aliases(module, "bff_http_methods")
     module_aliases = _collect_module_aliases(module)
     class_nodes = [node for node in module.body if isinstance(node, ast.ClassDef)]
+    replay_enabled = bool(replay_client)
+    replay_capsule = str((replay_client or {}).get("capsule", ""))
+    replay_key = tuple((replay_client or {}).get("key", b""))
+    replay_low_watermark = int(os.getenv("BFF_REPLAY_TOKEN_LOW_WATERMARK", "3"))
+    replay_state_url = f"{return_protocol}://{return_url}/_pytincture/state"
 
     decorated_class_nodes = [
         node for node in class_nodes
@@ -506,34 +665,115 @@ def generate_stub_classes(file_path, return_url, return_protocol):
             _, used_imports = get_imports_used_in_class(file_path, class_name)
             class_imports.update(used_imports)
             stub_class_code += f"\nclass {class_name}:\n"
-            stub_class_code += f"    def fetch_sync(self, url, payload=None, method='GET'):\n"
-            stub_class_code += f"        req = XMLHttpRequest.new()\n"
-            stub_class_code += f"        req.open(method, url, False)\n"
-            stub_class_code += f"        req.setRequestHeader('Content-Type', 'application/json')\n"
-            stub_class_code += f"        if payload:\n"
-            stub_class_code += f"            req.send(JSON.stringify(json.dumps(payload)))\n"
-            stub_class_code += f"        else:\n"
-            stub_class_code += f"            req.send()\n"
+            stub_class_code += f"    _pytincture_replay_enabled = {replay_enabled!r}\n"
+            stub_class_code += f"    _pytincture_replay_capsule = {replay_capsule!r}\n"
+            stub_class_code += f"    _pytincture_replay_key = {replay_key!r}\n"
+            stub_class_code += f"    _pytincture_replay_low = {replay_low_watermark!r}\n"
+            stub_class_code += "    _pytincture_replay_pool = []\n"
+            stub_class_code += "    def _csrf_token(self):\n"
+            stub_class_code += "        for cookie in str(document.cookie).split(';'):\n"
+            stub_class_code += "            name, separator, value = cookie.strip().partition('=')\n"
+            stub_class_code += "            if separator and name == 'pytincture_csrf':\n"
+            stub_class_code += "                return value\n"
+            stub_class_code += "        return ''\n"
+            stub_class_code += "    def _decode_pytincture_state(self, encoded):\n"
+            stub_class_code += "        padding = '=' * (-len(encoded) % 4)\n"
+            stub_class_code += "        packed = base64.urlsafe_b64decode((encoded + padding).encode('ascii'))\n"
+            stub_class_code += "        nonce, ciphertext, supplied_tag = packed[:16], packed[16:-16], packed[-16:]\n"
+            stub_class_code += "        key = bytes(self._pytincture_replay_key)\n"
+            stub_class_code += "        expected_tag = hmac.new(key, b'tag' + nonce + ciphertext, hashlib.sha256).digest()[:16]\n"
+            stub_class_code += "        if not hmac.compare_digest(supplied_tag, expected_tag):\n"
+            stub_class_code += "            raise RuntimeError('Unable to restore browser state')\n"
+            stub_class_code += "        plaintext = bytearray()\n"
+            stub_class_code += "        for offset in range(0, len(ciphertext), 32):\n"
+            stub_class_code += "            counter = (offset // 32).to_bytes(4, 'big')\n"
+            stub_class_code += "            stream = hmac.new(key, b'enc' + nonce + counter, hashlib.sha256).digest()\n"
+            stub_class_code += "            plaintext.extend(value ^ stream[index] for index, value in enumerate(ciphertext[offset:offset + 32]))\n"
+            stub_class_code += "        state = json.loads(bytes(plaintext).decode('utf-8'))\n"
+            stub_class_code += "        if state.get('v') != 1 or not isinstance(state.get('items'), list):\n"
+            stub_class_code += "            raise RuntimeError('Unable to restore browser state')\n"
+            stub_class_code += "        return state['items']\n"
+            stub_class_code += "    def _refill_pytincture_state_sync(self):\n"
+            stub_class_code += "        if not self._pytincture_replay_enabled:\n"
+            stub_class_code += "            return\n"
+            stub_class_code += "        req = XMLHttpRequest.new()\n"
+            stub_class_code += f"        req.open('POST', {replay_state_url!r}, False)\n"
+            stub_class_code += "        req.setRequestHeader('X-CSRF-Token', self._csrf_token())\n"
+            stub_class_code += "        req.setRequestHeader('X-Pytincture-Client', self._pytincture_replay_capsule)\n"
+            stub_class_code += "        req.send()\n"
+            stub_class_code += "        if req.status != 200:\n"
+            stub_class_code += "            raise RuntimeError('Unable to refresh browser state')\n"
+            stub_class_code += "        self._pytincture_replay_pool.extend(self._decode_pytincture_state(str(req.responseText)))\n"
+            stub_class_code += "    async def _refill_pytincture_state(self):\n"
+            stub_class_code += "        if not self._pytincture_replay_enabled:\n"
+            stub_class_code += "            return\n"
+            stub_class_code += "        from js import fetch\n"
+            stub_class_code += "        from pyodide.ffi import to_js\n"
+            stub_class_code += "        options = {'method': 'POST', 'headers': {'X-CSRF-Token': self._csrf_token(), 'X-Pytincture-Client': self._pytincture_replay_capsule}}\n"
+            stub_class_code += f"        response = await fetch({replay_state_url!r}, to_js(options))\n"
+            stub_class_code += "        if response.status != 200:\n"
+            stub_class_code += "            raise RuntimeError('Unable to refresh browser state')\n"
+            stub_class_code += "        self._pytincture_replay_pool.extend(self._decode_pytincture_state(await response.text()))\n"
+            stub_class_code += "    def _take_pytincture_state_sync(self):\n"
+            stub_class_code += "        if not self._pytincture_replay_enabled:\n"
+            stub_class_code += "            return ''\n"
+            stub_class_code += "        if not self._pytincture_replay_pool:\n"
+            stub_class_code += "            self._refill_pytincture_state_sync()\n"
+            stub_class_code += "        return self._pytincture_replay_pool.pop()\n"
+            stub_class_code += "    async def _take_pytincture_state(self):\n"
+            stub_class_code += "        if not self._pytincture_replay_enabled:\n"
+            stub_class_code += "            return ''\n"
+            stub_class_code += "        if not self._pytincture_replay_pool:\n"
+            stub_class_code += "            await self._refill_pytincture_state()\n"
+            stub_class_code += "        return self._pytincture_replay_pool.pop()\n"
+            stub_class_code += "    def fetch_sync(self, url, payload=None, method='GET', _replay_retry=True):\n"
+            stub_class_code += "        replay_token = self._take_pytincture_state_sync()\n"
+            stub_class_code += "        req = XMLHttpRequest.new()\n"
+            stub_class_code += "        req.open(method, url, False)\n"
+            stub_class_code += "        req.setRequestHeader('Content-Type', 'application/json')\n"
+            stub_class_code += "        if method != 'GET':\n"
+            stub_class_code += "            req.setRequestHeader('X-CSRF-Token', self._csrf_token())\n"
+            stub_class_code += "        if replay_token:\n"
+            stub_class_code += "            req.setRequestHeader('X-Pytincture-BFF-Token', replay_token)\n"
+            stub_class_code += "        if payload and method != 'GET':\n"
+            stub_class_code += "            req.send(JSON.stringify(json.dumps(payload)))\n"
+            stub_class_code += "        else:\n"
+            stub_class_code += "            req.send()\n"
+            stub_class_code += "        if _replay_retry and req.status == 409 and str(req.getResponseHeader('X-Pytincture-Replay')) == 'rejected':\n"
+            stub_class_code += "            self._pytincture_replay_pool.clear()\n"
+            stub_class_code += "            return self.fetch_sync(url, payload, method, False)\n"
             stub_class_code += f"        if req.status == 401:\n"
             stub_class_code += f"            from js import window\n"
             stub_class_code += f"            current_url = window.location.href.rstrip('/')\n"
             stub_class_code += f"            redirect_url = current_url + '/login'\n"
             stub_class_code += f"            window.location.href = redirect_url\n"
             stub_class_code += f"            return ''\n"
+            stub_class_code += "        if self._pytincture_replay_enabled and len(self._pytincture_replay_pool) <= self._pytincture_replay_low:\n"
+            stub_class_code += "            self._refill_pytincture_state_sync()\n"
             stub_class_code += f"        return StringIO(req.response).getvalue()\n"
             stub_class_code += f"\n"
-            stub_class_code += f"    async def fetch(self, url, payload=None, method='GET'):\n"
+            stub_class_code += f"    async def fetch(self, url, payload=None, method='GET', _replay_retry=True):\n"
             stub_class_code += f"        from js import fetch, JSON, window\n"
             stub_class_code += f"        from pyodide.ffi import to_js\n"
             stub_class_code += f"        options = {{'method': method, 'headers': {{'Content-Type': 'application/json'}}}}\n"
-            stub_class_code += f"        if payload is not None:\n"
+            stub_class_code += "        replay_token = await self._take_pytincture_state()\n"
+            stub_class_code += f"        if method != 'GET':\n"
+            stub_class_code += f"            options['headers']['X-CSRF-Token'] = self._csrf_token()\n"
+            stub_class_code += "        if replay_token:\n"
+            stub_class_code += "            options['headers']['X-Pytincture-BFF-Token'] = replay_token\n"
+            stub_class_code += f"        if payload is not None and method != 'GET':\n"
             stub_class_code += f"            options['body'] = JSON.stringify(json.dumps(payload))\n"
             stub_class_code += f"        response = await fetch(url, to_js(options))\n"
+            stub_class_code += "        if _replay_retry and response.status == 409 and response.headers.get('X-Pytincture-Replay') == 'rejected':\n"
+            stub_class_code += "            self._pytincture_replay_pool.clear()\n"
+            stub_class_code += "            return await self.fetch(url, payload, method, False)\n"
             stub_class_code += f"        if response.status == 401:\n"
             stub_class_code += f"            current_url = window.location.href.rstrip('/')\n"
             stub_class_code += f"            redirect_url = current_url + '/login'\n"
             stub_class_code += f"            window.location.href = redirect_url\n"
             stub_class_code += f"            return ''\n"
+            stub_class_code += "        if self._pytincture_replay_enabled and len(self._pytincture_replay_pool) <= self._pytincture_replay_low:\n"
+            stub_class_code += "            await self._refill_pytincture_state()\n"
             stub_class_code += f"        return await response.text()\n"
 
             streaming_methods = {}
@@ -551,19 +791,30 @@ def generate_stub_classes(file_path, return_url, return_protocol):
                             break
 
             if streaming_methods:
-                stub_class_code += f"    async def fetch_stream(self, url, payload=None, method='GET'):\n"
+                stub_class_code += f"    async def fetch_stream(self, url, payload=None, method='GET', _replay_retry=True):\n"
                 stub_class_code += f"        from js import fetch, TextDecoder\n"
                 stub_class_code += f"        from pyodide.ffi import to_js\n"
                 stub_class_code += f"        options = {{'method': method, 'headers': {{'Content-Type': 'application/json'}}}}\n"
+                stub_class_code += "        replay_token = await self._take_pytincture_state()\n"
+                stub_class_code += f"        options['headers']['X-CSRF-Token'] = self._csrf_token()\n"
+                stub_class_code += "        if replay_token:\n"
+                stub_class_code += "            options['headers']['X-Pytincture-BFF-Token'] = replay_token\n"
                 stub_class_code += f"        body_payload = payload if payload is not None else {{'args': [], 'kwargs': {{}}}}\n"
                 stub_class_code += f"        options['body'] = JSON.stringify(json.dumps(body_payload))\n"
                 stub_class_code += f"        response = await fetch(url, to_js(options))\n"
+                stub_class_code += "        if _replay_retry and response.status == 409 and response.headers.get('X-Pytincture-Replay') == 'rejected':\n"
+                stub_class_code += "            self._pytincture_replay_pool.clear()\n"
+                stub_class_code += "            async for retry_chunk in self.fetch_stream(url, payload, method, False):\n"
+                stub_class_code += "                yield retry_chunk\n"
+                stub_class_code += "            return\n"
                 stub_class_code += f"        if response.status == 401:\n"
                 stub_class_code += f"            from js import window\n"
                 stub_class_code += f"            current_url = window.location.href.rstrip('/')\n"
                 stub_class_code += f"            redirect_url = current_url + '/login'\n"
                 stub_class_code += f"            window.location.href = redirect_url\n"
                 stub_class_code += f"            return\n"
+                stub_class_code += "        if self._pytincture_replay_enabled and len(self._pytincture_replay_pool) <= self._pytincture_replay_low:\n"
+                stub_class_code += "            await self._refill_pytincture_state()\n"
                 stub_class_code += f"        reader = response.body.getReader()\n"
                 stub_class_code += f"        decoder = TextDecoder.new()\n"
                 stub_class_code += f"        while True:\n"
@@ -582,11 +833,17 @@ def generate_stub_classes(file_path, return_url, return_protocol):
                     is_streaming = node.name in streaming_methods
                     stream_config = streaming_methods.get(node.name, {"raw": False})
                     is_async_method = isinstance(node, ast.AsyncFunctionDef)
+                    declared_methods = _declared_http_methods(
+                        node.decorator_list,
+                        import_aliases=bff_http_method_aliases,
+                        module_aliases=module_aliases,
+                    )
+                    request_method = declared_methods[0]
                     if is_streaming:
                         stub_class_code += f"    async def {node.name}(self, *args, **kwargs):\n"
                         stub_class_code += f"        url = '{return_protocol}://{return_url}/classcall/{file_identifier}/{class_name}/{node.name}'\n"
                         stub_class_code +=  "        payload = {'args': args, 'kwargs': kwargs}\n"
-                        stub_class_code +=  "        stream_iter = self.fetch_stream(url, payload, 'POST')\n"
+                        stub_class_code += f"        stream_iter = self.fetch_stream(url, payload, '{request_method}')\n"
                         if stream_config.get("raw"):
                             stub_class_code +=  "        async for chunk in stream_iter:\n"
                             stub_class_code +=  "            if chunk:\n"
@@ -609,13 +866,13 @@ def generate_stub_classes(file_path, return_url, return_protocol):
                         stub_class_code += f"    async def {node.name}(self, *args, **kwargs):\n"
                         stub_class_code += f"        url = '{return_protocol}://{return_url}/classcall/{file_identifier}/{class_name}/{node.name}'\n"
                         stub_class_code +=  "        payload = {'args': args, 'kwargs': kwargs}\n"
-                        stub_class_code +=  "        response = await self.fetch(url, payload, 'POST')\n"
+                        stub_class_code += f"        response = await self.fetch(url, payload, '{request_method}')\n"
                         stub_class_code +=  "        return json.loads(response)\n"
                     else:
                         stub_class_code += f"    def {node.name}(self, *args, **kwargs):\n"
                         stub_class_code += f"        url = '{return_protocol}://{return_url}/classcall/{file_identifier}/{class_name}/{node.name}'\n"
                         stub_class_code +=  "        payload = {'args': args, 'kwargs': kwargs}\n"
-                        stub_class_code +=  "        response = self.fetch_sync(url, payload, 'POST')\n"
+                        stub_class_code += f"        response = self.fetch_sync(url, payload, '{request_method}')\n"
                         stub_class_code +=  "        return json.loads(response)\n"
                 elif isinstance(node, ast.Assign):
                     for target in node.targets:
@@ -626,19 +883,29 @@ def generate_stub_classes(file_path, return_url, return_protocol):
                             stub_class_code += f"        url = '{return_protocol}://{return_url}/classcall/{file_identifier}/{class_name}/{property_name}'\n"
                             stub_class_code +=  "        response = self.fetch_sync(url)\n"
                             stub_class_code +=  "        return json.loads(response)\n"
-        else:
-            stub_class_code += "\n"+ast.unparse(class_node)
-
     all_imports.add("import json")
-    all_imports.add("from js import XMLHttpRequest, JSON")
+    all_imports.add("import base64")
+    all_imports.add("import hashlib")
+    all_imports.add("import hmac")
+    all_imports.add("from js import XMLHttpRequest, JSON, document")
     all_imports.add("from io import StringIO")
     for imp in all_imports:
         stub_class_code = f"{imp}\n" + stub_class_code
 
     return stub_class_code
 
-def get_parsed_output(file_path, return_url, return_protocol="http"):
-    stub_code = generate_stub_classes(file_path, return_url, return_protocol)
+def get_parsed_output(
+    file_path,
+    return_url,
+    return_protocol="http",
+    replay_client=None,
+):
+    stub_code = generate_stub_classes(
+        file_path,
+        return_url,
+        return_protocol,
+        replay_client=replay_client,
+    )
     if stub_code:
         return stub_code
 

--- a/pytincture/frontend/package.json
+++ b/pytincture/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pytincture/runtime",
-  "version": "0.9.41",
+  "version": "0.10.0",
   "description": "Standalone pytincture.js runtime with inline app auto-start support.",
   "type": "module",
   "main": "dist/pytincture.js",
@@ -28,6 +28,6 @@
   "author": "schapman1974",
   "license": "MIT",
   "devDependencies": {
-    "esbuild": "^0.21.5"
+    "esbuild": "^0.28.1"
   }
 }

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -5,6 +5,9 @@ import json
 import textwrap
 import zipfile
 import tempfile
+import asyncio
+import subprocess
+import sys
 import pytest
 from pathlib import Path
 from fastapi.testclient import TestClient
@@ -19,6 +22,7 @@ from pytincture.backend.app import (
     _build_dynamic_module_name,
     _sanitize_return_to,
     set_bff_policy_hook,
+    set_user_authenticator,
 )
 from fastapi import HTTPException
 
@@ -45,6 +49,12 @@ def _tamper_token(token):
     return f"{token[:index]}{replacement}{token[index + 1:]}"
 
 
+def _csrf_headers(client):
+    token = client.cookies.get("pytincture_csrf")
+    assert token
+    return {"X-CSRF-Token": token}
+
+
 @pytest.fixture(autouse=True)
 def override_env(monkeypatch):
     """
@@ -61,17 +71,23 @@ def override_env(monkeypatch):
     monkeypatch.setattr(backend_app, "ENABLE_GOOGLE_AUTH", True)
     monkeypatch.setattr(backend_app, "ENABLE_MICROSOFT_AUTH", False)
     monkeypatch.setattr(backend_app, "ENABLE_USER_LOGIN", False)
+    monkeypatch.setattr(backend_app, "ENABLE_DEV_EMAIL_LOGIN", False)
     monkeypatch.setattr(backend_app, "ENABLE_SAML_AUTH", False)
+    monkeypatch.setattr(backend_app, "ENABLE_BFF_REPLAY_TOKENS", False)
     monkeypatch.setattr(backend_app, "USER_SESSION_DICT", {})
+    monkeypatch.setattr(backend_app, "AUTH_SESSION_REVOCATIONS", {})
+    monkeypatch.setattr(backend_app, "BFF_REPLAY_TOKEN_STORE", {})
+    set_user_authenticator(None)
     ALLOWED_NOAUTH_CLASSCALLS.clear()
     yield
+    set_user_authenticator(None)
 
 @pytest.fixture
 def fresh_client(override_env):
     """
     Provide a fresh TestClient instance with cleared cookies.
     """
-    client = TestClient(app)
+    client = TestClient(app, base_url="https://testserver")
     client.cookies.clear()
     return client
 
@@ -84,6 +100,9 @@ def dummy_module(tmp_path: Path):
     """
     dummy_file = tmp_path / "example.py"
     dummy_file.write_text(textwrap.dedent("""
+        from pytincture.dataclass import backend_for_frontend
+
+        @backend_for_frontend
         class ExampleClass:
             __widgetset__ = "dummywidget"
             __version__ = "1.0"
@@ -93,6 +112,408 @@ def dummy_module(tmp_path: Path):
                 return {"result": "success", "args": args, "kwargs": kwargs}
     """))
     return dummy_file.parent  # Return the directory containing example.py
+
+
+def test_user_login_requires_enabled_flag(fresh_client, monkeypatch):
+    import pytincture.backend.app as backend_app
+
+    monkeypatch.setattr(backend_app, "ENABLE_USER_LOGIN", False)
+    response = fresh_client.post(
+        "/demoapp/auth/user",
+        data={"email": "person@example.com", "password": "anything"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 403
+
+
+def test_password_hash_verifier_rejects_wrong_password(fresh_client, monkeypatch):
+    import pytincture.backend.app as backend_app
+    from argon2 import PasswordHasher
+
+    monkeypatch.setattr(backend_app, "ENABLE_GOOGLE_AUTH", False)
+    monkeypatch.setattr(backend_app, "ENABLE_USER_LOGIN", True)
+    monkeypatch.setattr(backend_app, "ENABLE_DEV_EMAIL_LOGIN", False)
+    monkeypatch.setenv("ALLOWED_EMAILS", "person@example.com")
+    monkeypatch.setenv(
+        "AUTH_PASSWORD_HASHES",
+        json.dumps({"person@example.com": PasswordHasher().hash("correct-password")}),
+    )
+
+    wrong = fresh_client.post(
+        "/demoapp/auth/user",
+        data={"email": "person@example.com", "password": "wrong-password"},
+        follow_redirects=False,
+    )
+    assert wrong.status_code == 401
+
+    correct = fresh_client.post(
+        "/demoapp/auth/user",
+        data={"email": "person@example.com", "password": "correct-password"},
+        follow_redirects=False,
+    )
+    assert correct.status_code == 303
+
+
+def test_development_email_login_is_loopback_only(monkeypatch):
+    import pytincture.backend.app as backend_app
+
+    monkeypatch.setattr(backend_app, "ENABLE_GOOGLE_AUTH", False)
+    monkeypatch.setattr(backend_app, "ENABLE_USER_LOGIN", True)
+    monkeypatch.setattr(backend_app, "ENABLE_DEV_EMAIL_LOGIN", True)
+    monkeypatch.setenv("ALLOWED_EMAILS", "person@example.com")
+    with TestClient(app, base_url="https://public.example.com") as client:
+        response = client.post(
+            "/demoapp/auth/user",
+            data={"email": "person@example.com", "password": "ignored"},
+            follow_redirects=False,
+        )
+    assert response.status_code == 401
+
+
+def test_authentication_enabled_requires_strong_startup_secret(tmp_path):
+    environment = os.environ.copy()
+    environment.update({
+        "ENABLE_USER_LOGIN": "true",
+        "ENABLE_GOOGLE_AUTH": "false",
+        "ENABLE_MICROSOFT_AUTH": "false",
+        "ENABLE_SAML_AUTH": "false",
+        "PYTHONPATH": str(Path(__file__).parents[1]),
+    })
+    environment.pop("SAML_SECRET_KEY", None)
+    environment.pop("SECRET_KEY", None)
+    result = subprocess.run(
+        [sys.executable, "-c", "import pytincture.backend.app"],
+        cwd=tmp_path,
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode != 0
+    assert "Authentication requires SAML_SECRET_KEY" in result.stderr
+
+
+def test_dependency_routes_reject_missing_authenticated_session(
+    fresh_client, monkeypatch, tmp_path
+):
+    import pytincture.backend.app as backend_app
+
+    monkeypatch.setattr(backend_app, "ENABLE_GOOGLE_AUTH", True)
+    monkeypatch.setenv("MODULES_PATH", str(tmp_path))
+    assert fresh_client.post("/logs", json={}).status_code == 401
+    assert fresh_client.get("/demoapp/appcode/appcode.pyt").status_code == 401
+
+
+def test_unknown_bff_target_is_rejected_before_module_execution(
+    fresh_client, monkeypatch, tmp_path
+):
+    import pytincture.backend.app as backend_app
+
+    marker = tmp_path / "executed"
+    (tmp_path / "danger.py").write_text(
+        "from pathlib import Path\n"
+        f"Path({str(marker)!r}).write_text('imported')\n"
+        "class Danger:\n"
+        "    def run(self): return True\n"
+    )
+    monkeypatch.setenv("MODULES_PATH", str(tmp_path))
+    monkeypatch.setattr(backend_app, "require_auth", lambda request: {"email": "user@example.com"})
+    response = fresh_client.post("/classcall/danger.py/Danger/run", json={})
+    assert response.status_code == 404
+    assert not marker.exists()
+
+
+def test_async_policy_runs_before_constructor(fresh_client, monkeypatch, tmp_path):
+    import pytincture.backend.app as backend_app
+
+    marker = tmp_path / "constructed"
+    (tmp_path / "restricted.py").write_text(textwrap.dedent(f"""
+        from pathlib import Path
+        from pytincture.dataclass import backend_for_frontend, bff_policy
+
+        @backend_for_frontend
+        class Restricted:
+            def __init__(self):
+                Path({str(marker)!r}).write_text("constructed")
+
+            @bff_policy(role="admin")
+            def run(self):
+                return True
+    """))
+    monkeypatch.setenv("MODULES_PATH", str(tmp_path))
+    monkeypatch.setattr(backend_app, "require_auth", lambda request: {"roles": []})
+
+    async def deny_policy(**kwargs):
+        await asyncio.sleep(0)
+        raise HTTPException(status_code=403, detail="Forbidden")
+
+    set_bff_policy_hook(deny_policy)
+    try:
+        response = fresh_client.post("/classcall/restricted.py/Restricted/run", json={})
+    finally:
+        set_bff_policy_hook(None)
+    assert response.status_code == 403
+    assert not marker.exists()
+
+
+def test_state_changing_bff_call_requires_csrf(
+    fresh_client, monkeypatch, dummy_module
+):
+    import pytincture.backend.app as backend_app
+
+    monkeypatch.setattr(backend_app, "ENABLE_GOOGLE_AUTH", False)
+    monkeypatch.setattr(backend_app, "ENABLE_USER_LOGIN", True)
+    monkeypatch.setattr(backend_app, "ENABLE_DEV_EMAIL_LOGIN", True)
+    monkeypatch.setenv("ALLOWED_EMAILS", "person@example.com")
+    monkeypatch.setenv("MODULES_PATH", str(dummy_module))
+    fresh_client.post(
+        "/demoapp/auth/user",
+        data={"email": "person@example.com", "password": "local"},
+        follow_redirects=False,
+    )
+    without_token = fresh_client.post(
+        "/classcall/example.py/ExampleClass/testfunc", json={}
+    )
+    assert without_token.status_code == 403
+    with_token = fresh_client.post(
+        "/classcall/example.py/ExampleClass/testfunc",
+        json={},
+        headers=_csrf_headers(fresh_client),
+    )
+    assert with_token.status_code == 200
+
+
+def test_bff_replay_token_is_opaque_session_bound_and_single_use(
+    fresh_client, monkeypatch, dummy_module
+):
+    import ast
+    import re
+    import pytincture.backend.app as backend_app
+
+    monkeypatch.setattr(backend_app, "ENABLE_GOOGLE_AUTH", False)
+    monkeypatch.setattr(backend_app, "ENABLE_USER_LOGIN", True)
+    monkeypatch.setattr(backend_app, "ENABLE_DEV_EMAIL_LOGIN", True)
+    monkeypatch.setattr(backend_app, "ENABLE_BFF_REPLAY_TOKENS", True)
+    monkeypatch.setattr(backend_app, "BFF_REPLAY_TOKEN_BATCH_SIZE", 4)
+    monkeypatch.setattr(backend_app, "BFF_REPLAY_TOKEN_LOW_WATERMARK", 1)
+    monkeypatch.setenv("BFF_REPLAY_TOKEN_LOW_WATERMARK", "1")
+    monkeypatch.setenv("ALLOWED_EMAILS", "person@example.com")
+    monkeypatch.setenv("MODULES_PATH", str(dummy_module))
+    backend_app.reload_bff_registry(str(dummy_module))
+
+    login = fresh_client.post(
+        "/example/auth/user",
+        data={"email": "person@example.com", "password": "local"},
+        follow_redirects=False,
+    )
+    assert login.status_code == 303
+
+    package = fresh_client.get("/example/appcode/appcode.pyt")
+    assert package.status_code == 200
+    with zipfile.ZipFile(io.BytesIO(package.content)) as archive:
+        stub = archive.read("example.py").decode("utf-8")
+    capsule_match = re.search(r"_pytincture_replay_capsule = (.+)", stub)
+    key_match = re.search(r"_pytincture_replay_key = (.+)", stub)
+    assert capsule_match and key_match
+    capsule = ast.literal_eval(capsule_match.group(1))
+    client_key = bytes(ast.literal_eval(key_match.group(1)))
+
+    state_headers = {
+        **_csrf_headers(fresh_client),
+        "X-Pytincture-Client": capsule,
+    }
+    state_response = fresh_client.post("/_pytincture/state", headers=state_headers)
+    assert state_response.status_code == 200
+    assert state_response.headers["content-type"].startswith("application/octet-stream")
+    decoded = json.loads(
+        backend_app._decrypt_opaque_envelope(client_key, state_response.text)
+    )
+    assert decoded["v"] == 1
+    assert len(decoded["items"]) == 4
+    assert all(token not in state_response.text for token in decoded["items"])
+
+    # The capsule is stateless: a stable backend secret can recover the client
+    # key and issue a fresh opaque pool after process-local token state is lost.
+    backend_app.BFF_REPLAY_TOKEN_STORE.clear()
+    after_restart = fresh_client.post("/_pytincture/state", headers=state_headers)
+    assert after_restart.status_code == 200
+
+    call_headers = {
+        **_csrf_headers(fresh_client),
+    }
+    # Use a token from the post-restart refill because pre-restart tokens were
+    # deliberately invalidated with process-local storage.
+    restarted_tokens = json.loads(
+        backend_app._decrypt_opaque_envelope(client_key, after_restart.text)
+    )["items"]
+    call_headers["X-Pytincture-BFF-Token"] = restarted_tokens[0]
+    first = fresh_client.post(
+        "/classcall/example.py/ExampleClass/testfunc",
+        json={},
+        headers=call_headers,
+    )
+    copied_curl_replay = fresh_client.post(
+        "/classcall/example.py/ExampleClass/testfunc",
+        json={},
+        headers=call_headers,
+    )
+    assert first.status_code == 200
+    assert copied_curl_replay.status_code == 409
+
+
+def test_bff_methods_default_to_post(fresh_client, monkeypatch, dummy_module):
+    import pytincture.backend.app as backend_app
+
+    monkeypatch.setenv("MODULES_PATH", str(dummy_module))
+    monkeypatch.setattr(backend_app, "require_auth", lambda request: {"email": "user@example.com"})
+    response = fresh_client.get("/classcall/example.py/ExampleClass/testfunc")
+    assert response.status_code == 405
+    assert response.headers["allow"] == "POST"
+
+
+def test_revoked_session_is_rejected(fresh_client, monkeypatch, dummy_module):
+    import pytincture.backend.app as backend_app
+
+    monkeypatch.setattr(backend_app, "ENABLE_GOOGLE_AUTH", False)
+    monkeypatch.setattr(backend_app, "ENABLE_USER_LOGIN", True)
+    monkeypatch.setattr(backend_app, "ENABLE_DEV_EMAIL_LOGIN", True)
+    monkeypatch.setenv("ALLOWED_EMAILS", "person@example.com")
+    monkeypatch.setenv("MODULES_PATH", str(dummy_module))
+    fresh_client.post(
+        "/demoapp/auth/user",
+        data={"email": "person@example.com", "password": "local"},
+        follow_redirects=False,
+    )
+    session_data = _decode_session_cookie(fresh_client, backend_app.SAML_SECRET_KEY)
+    backend_app.revoke_session(session_data["session_id"])
+    response = fresh_client.post(
+        "/classcall/example.py/ExampleClass/testfunc",
+        json={},
+        headers=_csrf_headers(fresh_client),
+    )
+    assert response.status_code == 401
+
+
+def test_session_key_rotation_accepts_and_resigns_previous_key():
+    from fastapi import FastAPI, Request
+    from pytincture.backend.app import RotatingSessionMiddleware
+
+    old_key = "old-key-with-at-least-thirty-two-random-chars"
+    new_key = "new-key-with-at-least-thirty-two-random-chars"
+    mini_app = FastAPI()
+
+    @mini_app.get("/")
+    async def read_session(request: Request):
+        return request.session
+
+    mini_app.add_middleware(
+        RotatingSessionMiddleware,
+        secret_key=new_key,
+        previous_secret_keys=[old_key],
+        https_only=True,
+    )
+    encoded = base64.b64encode(json.dumps({"user": "legacy"}).encode())
+    old_cookie = TimestampSigner(old_key).sign(encoded).decode()
+    with TestClient(mini_app, base_url="https://testserver") as client:
+        client.cookies.set("session", old_cookie)
+        response = client.get("/")
+        assert response.json() == {"user": "legacy"}
+        resigned = response.headers["set-cookie"].split("session=", 1)[1].split(";", 1)[0]
+    decoded = TimestampSigner(new_key).unsign(resigned)
+    assert json.loads(base64.b64decode(decoded)) == {"user": "legacy"}
+
+
+def test_raw_server_files_are_not_public_assets(fresh_client, monkeypatch, tmp_path):
+    monkeypatch.setenv("MODULES_PATH", str(tmp_path))
+    (tmp_path / "server.py").write_text("SECRET = 'hidden'\n")
+    (tmp_path / ".env").write_text("SECRET=hidden\n")
+    (tmp_path / "logo.png").write_bytes(b"png")
+
+    assert fresh_client.get("/demoapp/appcode/server.py").status_code == 404
+    assert fresh_client.get("/demoapp/appcode/.env").status_code == 404
+    assert fresh_client.get("/demoapp/appcode/logo.png").status_code == 200
+
+
+def test_browser_package_excludes_unreachable_server_modules(
+    fresh_client, monkeypatch, tmp_path
+):
+    import pytincture.backend.app as backend_app
+
+    monkeypatch.setattr(backend_app, "ENABLE_GOOGLE_AUTH", False)
+    monkeypatch.setattr(backend_app, "ENABLE_USER_LOGIN", False)
+    monkeypatch.setenv("MODULES_PATH", str(tmp_path))
+    (tmp_path / "demoapp.py").write_text("from service import Service\n")
+    (tmp_path / "service.py").write_text(textwrap.dedent("""
+        from pytincture.dataclass import backend_for_frontend
+        class ServerHelper:
+            secret = "helper-must-not-ship"
+        @backend_for_frontend
+        class Service:
+            def secret(self):
+                return "must-not-ship"
+    """))
+    (tmp_path / "server_only.py").write_text("SECRET = 'must-not-ship'\n")
+
+    response = fresh_client.get("/demoapp/appcode/appcode.pyt")
+    assert response.status_code == 200
+    with zipfile.ZipFile(io.BytesIO(response.content)) as archive:
+        assert set(archive.namelist()) == {"demoapp.py", "service.py"}
+        assert "must-not-ship" not in archive.read("service.py").decode()
+        assert "ServerHelper" not in archive.read("service.py").decode()
+
+
+def test_mcp_has_no_automatic_tools_and_rejects_sensitive_allowlist(monkeypatch):
+    import pytincture.backend.app as backend_app
+
+    assert asyncio.run(backend_app.mcp.get_tools()) == {}
+    monkeypatch.setenv("ENABLE_MCP", "true")
+    monkeypatch.setenv("MCP_EXPOSED_OPERATIONS", '["handleUserAuth"]')
+    with pytest.raises(RuntimeError, match="session/login/application"):
+        backend_app._mcp_operation_ids()
+
+
+def test_mcp_classcall_cannot_bypass_http_authentication(monkeypatch, tmp_path):
+    import pytincture.backend.app as backend_app
+
+    (tmp_path / "service.py").write_text(textwrap.dedent("""
+        from pytincture.dataclass import backend_for_frontend
+        @backend_for_frontend
+        class Service:
+            def run(self):
+                return True
+    """))
+    monkeypatch.setenv("MODULES_PATH", str(tmp_path))
+    monkeypatch.setattr(backend_app, "ENABLE_GOOGLE_AUTH", True)
+    backend_app.reload_bff_registry(str(tmp_path))
+    mcp_server = backend_app.FastMCP.from_fastapi(
+        backend_app._FilteredFastAPIApp(app, {"postClassCall"}),
+        name="security-test",
+    )
+
+    async def invoke_tool():
+        tool = (await mcp_server.get_tools())["postClassCall"]
+        return await tool.run({
+            "file_path": "service.py",
+            "class_name": "Service",
+            "function_name": "run",
+        })
+
+    with pytest.raises(ValueError, match="HTTP error 401"):
+        asyncio.run(invoke_tool())
+
+
+def test_validation_error_does_not_echo_request_body(fresh_client):
+    response = fresh_client.post(
+        "/demoapp/auth/mcp",
+        json={"email": "person@example.com", "secret": "must-not-echo"},
+    )
+    assert response.status_code == 422
+    assert "must-not-echo" not in response.text
+
+
+def test_request_body_limit_rejects_oversized_payload(fresh_client):
+    response = fresh_client.post("/logs", content=b"x" * (2 * 1024 * 1024 + 1))
+    assert response.status_code == 413
 
 def test_favicon(fresh_client):
     """Test the /favicon.ico route (placeholder)."""
@@ -143,8 +564,10 @@ def test_main_route_ignores_backend_session_snapshot(fresh_client, monkeypatch):
 
     monkeypatch.setattr(backend_app, "ENABLE_GOOGLE_AUTH", False)
     monkeypatch.setattr(backend_app, "ENABLE_USER_LOGIN", True)
+    monkeypatch.setattr(backend_app, "ENABLE_DEV_EMAIL_LOGIN", True)
     monkeypatch.setattr(backend_app, "ENABLE_SAML_AUTH", False)
     monkeypatch.setattr(backend_app, "USER_SESSION_DICT", {})
+    monkeypatch.setenv("ALLOWED_EMAILS", "stale@example.com")
 
     response = fresh_client.post(
         "/demoapp/auth/user",
@@ -213,7 +636,9 @@ def test_class_call_noauth(dummy_module, monkeypatch, fresh_client):
     }]
     ALLOWED_NOAUTH_CLASSCALLS.extend(allowed_calls)
     fresh_client.cookies.clear()
-    response = fresh_client.get("/classcall/example.py/ExampleClass/testfunc")
+    response = fresh_client.post(
+        "/classcall/example.py/ExampleClass/testfunc", json={"kwargs": {}}
+    )
     assert response.status_code == 200
     json_response = response.json()
     assert json_response.get("result") == "success"
@@ -331,7 +756,7 @@ def test_class_call_loads_decorated_module_without_standard_import(monkeypatch, 
     monkeypatch.setenv("MODULES_PATH", str(modules_dir))
     monkeypatch.setattr(backend_app, "require_auth", lambda request: {"email": "tester@example.com"})
 
-    response = fresh_client.get("/classcall/direct_load.py/DirectLoad/ping")
+    response = fresh_client.post("/classcall/direct_load.py/DirectLoad/ping", json={})
     assert response.status_code == 200
     assert response.json()["status"] == "ok"
 
@@ -360,7 +785,7 @@ def test_class_call_decorated_constructor_receives_user(monkeypatch, fresh_clien
     monkeypatch.setenv("MODULES_PATH", str(modules_dir))
     monkeypatch.setattr(backend_app, "require_auth", lambda request: {"email": "tester@example.com"})
 
-    response = fresh_client.get("/classcall/user_aware.py/UserAware/whoami")
+    response = fresh_client.post("/classcall/user_aware.py/UserAware/whoami", json={})
     assert response.status_code == 200
     assert response.json()["email"] == "tester@example.com"
 
@@ -410,6 +835,9 @@ def test_class_call_nested_module_path(monkeypatch, fresh_client, tmp_path):
     target_dir = modules_dir / "pkg" / "internal"
     target_dir.mkdir(parents=True)
     module_code = textwrap.dedent("""
+        from pytincture.dataclass import backend_for_frontend
+
+        @backend_for_frontend
         class Worker:
             def __init__(self, _user):
                 self._user = _user
@@ -438,6 +866,9 @@ def test_class_call_noauth_nested_path(monkeypatch, fresh_client, tmp_path):
     target_dir = modules_dir / "pkg" / "internal"
     target_dir.mkdir(parents=True)
     module_code = textwrap.dedent("""
+        from pytincture.dataclass import backend_for_frontend
+
+        @backend_for_frontend
         class Worker:
             def __init__(self, _user):
                 self._user = _user
@@ -455,7 +886,9 @@ def test_class_call_noauth_nested_path(monkeypatch, fresh_client, tmp_path):
         "function": "ping"
     }])
 
-    response = fresh_client.get("/classcall/pkg/internal/worker.py/Worker/ping")
+    response = fresh_client.post(
+        "/classcall/pkg/internal/worker.py/Worker/ping", json={}
+    )
     assert response.status_code == 200
     assert response.json()["status"] == "ok"
 
@@ -508,6 +941,7 @@ def test_download_appcode(fresh_client, monkeypatch, tmp_path):
     # Create a dummy modules folder with a file.
     dummy_dir = tmp_path / "dummy_modules"
     dummy_dir.mkdir()
+    (dummy_dir / "demoapp.py").write_text("class Demo: pass\n")
     (dummy_dir / "dummy.txt").write_text("dummy content")
     monkeypatch.setenv("MODULES_PATH", str(dummy_dir))
     # Override require_auth to simulate a valid user.
@@ -606,7 +1040,9 @@ def test_require_auth_does_not_print_debug_output(monkeypatch, capsys):
     import pytincture.backend.app as backend_app
 
     user = backend_app._build_auth_session_user({"email": "quiet@example.com"})
-    request = type("Request", (), {"session": {"user": user}})()
+    request = type("Request", (), {
+        "session": {"user": user, "session_id": "test-session"}
+    })()
 
     monkeypatch.setattr(backend_app, "ENABLE_GOOGLE_AUTH", True)
     monkeypatch.setattr(backend_app, "ENABLE_USER_LOGIN", False)
@@ -620,6 +1056,7 @@ def test_user_login_stores_only_compact_stateless_claims(fresh_client, monkeypat
 
     monkeypatch.setattr(backend_app, "ENABLE_GOOGLE_AUTH", False)
     monkeypatch.setattr(backend_app, "ENABLE_USER_LOGIN", True)
+    monkeypatch.setattr(backend_app, "ENABLE_DEV_EMAIL_LOGIN", True)
     monkeypatch.setattr(backend_app, "ENABLE_SAML_AUTH", False)
     monkeypatch.setenv("ALLOWED_EMAILS", "person@example.com")
     monkeypatch.setattr(backend_app, "USER_SESSION_DICT", {"sentinel": {"value": True}})
@@ -651,6 +1088,7 @@ def test_stateless_session_survives_logout_in_another_browser_and_replica(
 
     monkeypatch.setattr(backend_app, "ENABLE_GOOGLE_AUTH", False)
     monkeypatch.setattr(backend_app, "ENABLE_USER_LOGIN", True)
+    monkeypatch.setattr(backend_app, "ENABLE_DEV_EMAIL_LOGIN", True)
     monkeypatch.setattr(backend_app, "ENABLE_SAML_AUTH", False)
     monkeypatch.setenv("ALLOWED_EMAILS", "person@example.com")
     monkeypatch.setenv("MODULES_PATH", str(dummy_module))
@@ -662,7 +1100,9 @@ def test_stateless_session_survives_logout_in_another_browser_and_replica(
     )
     assert first_login.status_code == 303
 
-    with TestClient(app) as second_browser, TestClient(app) as another_replica:
+    with TestClient(app, base_url="https://testserver") as second_browser, TestClient(
+        app, base_url="https://testserver"
+    ) as another_replica:
         second_login = second_browser.post(
             "/demoapp/auth/user",
             data={"email": "person@example.com", "password": "second"},
@@ -670,7 +1110,9 @@ def test_stateless_session_survives_logout_in_another_browser_and_replica(
         )
         assert second_login.status_code == 303
         second_cookie = second_browser.cookies.get("session")
+        second_csrf_cookie = second_browser.cookies.get("pytincture_csrf")
         assert second_cookie
+        assert second_csrf_cookie
 
         backend_app.USER_SESSION_DICT["person@example.com"] = {
             "email": "person@example.com",
@@ -679,9 +1121,11 @@ def test_stateless_session_survives_logout_in_another_browser_and_replica(
         fresh_client.get("/demoapp/auth/logout", follow_redirects=False)
 
         another_replica.cookies.set("session", second_cookie)
+        another_replica.cookies.set("pytincture_csrf", second_csrf_cookie)
         response = another_replica.post(
             "/classcall/example.py/ExampleClass/testfunc",
             json={"kwargs": {"source": "replica"}},
+            headers=_csrf_headers(another_replica),
         )
 
     assert response.status_code == 200
@@ -697,6 +1141,7 @@ def test_tampered_and_expired_stateless_sessions_are_rejected(
 
     monkeypatch.setattr(backend_app, "ENABLE_GOOGLE_AUTH", False)
     monkeypatch.setattr(backend_app, "ENABLE_USER_LOGIN", True)
+    monkeypatch.setattr(backend_app, "ENABLE_DEV_EMAIL_LOGIN", True)
     monkeypatch.setattr(backend_app, "ENABLE_SAML_AUTH", False)
     monkeypatch.setenv("ALLOWED_EMAILS", "person@example.com")
     monkeypatch.setenv("MODULES_PATH", str(dummy_module))
@@ -957,8 +1402,10 @@ def test_saml_acs_creates_compact_session_that_authorizes_bff_calls(
     assert "saml_session_index" not in session_data
 
     backend_app.USER_SESSION_DICT["person@example.com"] = {"stale": True}
-    bff_response = fresh_client.get(
-        "/classcall/example.py/ExampleClass/testfunc"
+    bff_response = fresh_client.post(
+        "/classcall/example.py/ExampleClass/testfunc",
+        json={},
+        headers=_csrf_headers(fresh_client),
     )
     assert bff_response.status_code == 200
 
@@ -968,6 +1415,8 @@ def test_login_endpoint(fresh_client, monkeypatch, tmp_path):
     Test the /{application}/login endpoint returns expected HTML content.
     """
     import pytincture.backend.app as backend_app
+    monkeypatch.setattr(backend_app, "ENABLE_USER_LOGIN", True)
+    monkeypatch.setattr(backend_app, "ENABLE_DEV_EMAIL_LOGIN", True)
     monkeypatch.setenv("ENABLE_GOOGLE_AUTH", "true")
     monkeypatch.setenv("ENABLE_USER_LOGIN", "true")
     # Create a dummy frontend directory with an index.html.
@@ -1062,6 +1511,8 @@ def test_auth_user_callback(fresh_client, monkeypatch):
     Test the /{application}/auth/user endpoint simulating email/password login.
     """
     import pytincture.backend.app as backend_app
+    monkeypatch.setattr(backend_app, "ENABLE_USER_LOGIN", True)
+    monkeypatch.setattr(backend_app, "ENABLE_DEV_EMAIL_LOGIN", True)
     monkeypatch.setenv("ALLOWED_EMAILS", "test@example.com")
     response = fresh_client.post(
         "/demoapp/auth/user",
@@ -1459,8 +1910,11 @@ def test_saml_provider_metadata_route_uses_provider_config(fresh_client, monkeyp
         "idp_x509_cert": dummy_cert,
     }])
 
-    response = fresh_client.get("/demoapp/auth/saml/company-a/metadata")
+    response = fresh_client.get(
+        "/demoapp/auth/saml/company-a/metadata",
+        headers={"host": "service.example.com"},
+    )
     assert response.status_code == 200
     assert "EntityDescriptor" in response.text
-    assert "http://testserver/demoapp/auth/saml/metadata" in response.text
-    assert "http://testserver/demoapp/auth/saml/acs" in response.text
+    assert "https://service.example.com/demoapp/auth/saml/metadata" in response.text
+    assert "https://service.example.com/demoapp/auth/saml/acs" in response.text

--- a/tests/test_dataclass.py
+++ b/tests/test_dataclass.py
@@ -8,7 +8,9 @@ from pathlib import Path
 # Import functions to test from dataclass.py
 from pytincture.dataclass import (
     backend_for_frontend,
+    bff_http_methods,
     bff_stream,
+    get_bff_manifest,
     get_imports_used_in_class,
     generate_stub_classes,
     get_parsed_output,
@@ -76,6 +78,37 @@ def test_backend_for_frontend_stream_registration():
     finally:
         bff_routes.clear()
         bff_routes.update(previous_routes)
+
+
+def test_bff_http_methods_and_static_manifest(tmp_path):
+    file_path = tmp_path / "reports.py"
+    file_path.write_text(textwrap.dedent("""
+        from pytincture.dataclass import backend_for_frontend, bff_http_methods, bff_policy
+
+        @backend_for_frontend
+        @bff_policy(tenant="acme")
+        class Reports:
+            @bff_http_methods("GET")
+            @bff_policy(role="reader")
+            def status(self):
+                return {"ready": True}
+
+            def refresh(self):
+                return {"ready": True}
+    """))
+
+    manifest = get_bff_manifest(str(file_path))
+    assert manifest[("Reports", "status")] == {
+        "policy": {"tenant": "acme", "role": "reader"},
+        "http_methods": ("GET",),
+        "kind": "method",
+    }
+    assert manifest[("Reports", "refresh")]["http_methods"] == ("POST",)
+
+
+def test_bff_http_methods_rejects_unsupported_method():
+    with pytest.raises(ValueError):
+        bff_http_methods("TRACE")
 
 # --------------------------------------------
 # Tests for get_imports_used_in_class
@@ -147,7 +180,7 @@ def test_generate_stub_classes_returns_stub(tmp_path, monkeypatch):
     stub = generate_stub_classes(str(file_path), "example.com", "https")
     # Sync backend methods should keep synchronous stubs.
     assert "class MyService:" in stub
-    assert "async def fetch(self, url, payload=None, method='GET'):" in stub
+    assert "async def fetch(self, url, payload=None, method='GET', _replay_retry=True):" in stub
     assert "def foo(self, *args, **kwargs):" in stub
     assert "response = self.fetch_sync(url, payload, 'POST')" in stub
     assert "async def foo(self, *args, **kwargs):" not in stub
@@ -204,7 +237,7 @@ def test_generate_stub_classes_supports_decorator_aliases_and_async_methods(tmp_
 
     stub = generate_stub_classes(str(file_path), "example.com", "https")
     assert "class AsyncService:" in stub
-    assert "async def fetch(self, url, payload=None, method='GET'):" in stub
+    assert "async def fetch(self, url, payload=None, method='GET', _replay_retry=True):" in stub
     assert "async def ticker(self, *args, **kwargs):" in stub
     assert "async def ping(self, *args, **kwargs):" in stub
     assert "response = await self.fetch(url, payload, 'POST')" in stub
@@ -252,6 +285,54 @@ def test_generate_stub_classes_nested_path(tmp_path, monkeypatch):
     stub = generate_stub_classes(str(file_path), "example.com", "https")
     expected_url = "https://example.com/classcall/api/v1/service.py/NestedService/ping"
     assert expected_url in stub
+
+
+def test_generated_stub_sends_csrf_and_declared_http_method(tmp_path, monkeypatch):
+    file_path = tmp_path / "status.py"
+    file_path.write_text(textwrap.dedent("""
+        from pytincture.dataclass import backend_for_frontend, bff_http_methods
+
+        @backend_for_frontend
+        class Status:
+            @bff_http_methods("GET")
+            def read(self):
+                return True
+    """))
+    monkeypatch.setenv("MODULES_PATH", str(tmp_path))
+
+    stub = generate_stub_classes(str(file_path), "example.com", "https")
+    assert "X-CSRF-Token" in stub
+    assert "pytincture_csrf" in stub
+    assert "response = self.fetch_sync(url, payload, 'GET')" in stub
+
+
+def test_generated_stub_injects_opaque_replay_state_client(tmp_path, monkeypatch):
+    file_path = tmp_path / "service.py"
+    file_path.write_text(textwrap.dedent("""
+        from pytincture.dataclass import backend_for_frontend
+
+        @backend_for_frontend
+        class Service:
+            def read(self):
+                return True
+    """))
+    monkeypatch.setenv("MODULES_PATH", str(tmp_path))
+    replay_client = {"capsule": "opaque-capsule", "key": bytes(range(32))}
+
+    stub = generate_stub_classes(
+        str(file_path),
+        "example.com",
+        "https",
+        replay_client=replay_client,
+    )
+
+    assert "_pytincture_replay_enabled = True" in stub
+    assert "_pytincture_replay_capsule = 'opaque-capsule'" in stub
+    assert "https://example.com/_pytincture/state" in stub
+    assert "X-Pytincture-BFF-Token" in stub
+    assert "X-Pytincture-Client" in stub
+    assert "_decode_pytincture_state" in stub
+    compile(stub, str(file_path), "exec")
 
 def test_get_parsed_output_returns_stub(tmp_path):
     """

--- a/uv.lock
+++ b/uv.lock
@@ -1,14 +1,18 @@
 version = 1
 revision = 2
-requires-python = ">=3.13"
+requires-python = ">=3.13, <3.15"
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version < '3.14'",
+]
 
 [[package]]
 name = "aiofiles"
-version = "24.1.0"
+version = "25.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0b/03/a88171e277e8caa88a4c77808c20ebb04ba74cc4681bf1e9416c862de237/aiofiles-24.1.0.tar.gz", hash = "sha256:22a075c9e5a3810f0c2e48f3008c94d68c65d763b9b03857924c99e57355166c", size = 30247, upload-time = "2024-06-24T11:02:03.584Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/c3/534eac40372d8ee36ef40df62ec129bee4fdb5ad9706e58a29be53b2c970/aiofiles-25.1.0.tar.gz", hash = "sha256:a8d728f0a29de45dc521f18f07297428d56992a742f0cd2701ba86e44d23d5b2", size = 46354, upload-time = "2025-10-09T20:51:04.358Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/45/30bb92d442636f570cb5651bc661f52b610e2eec3f891a5dc3a4c3667db0/aiofiles-24.1.0-py3-none-any.whl", hash = "sha256:b4ec55f4195e3eb5d7abd1bf7e061763e864dd4954231fb8539a0ef8bb8260e5", size = 15896, upload-time = "2024-06-24T11:02:01.529Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl", hash = "sha256:abe311e527c862958650f9438e859c1fa7568a141b22abcd015e120e86a85695", size = 14668, upload-time = "2025-10-09T20:51:03.174Z" },
 ]
 
 [[package]]
@@ -22,6 +26,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2e/cf/9eb144a0b05809ffc5d29045c4b51039000ea275bc1268d0351c9e7dfc06/aioredis-2.0.1.tar.gz", hash = "sha256:eaa51aaf993f2d71f54b70527c440437ba65340588afeb786cd87c55c89cd98e", size = 111047, upload-time = "2021-12-27T20:28:17.557Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/a9/0da089c3ae7a31cbcd2dcf0214f6f571e1295d292b6139e2bac68ec081d0/aioredis-2.0.1-py3-none-any.whl", hash = "sha256:9ac0d0b3b485d293b8ca1987e6de8658d7dafcca1cddfcd1d506cae8cdebfdd6", size = 71243, upload-time = "2021-12-27T20:28:16.36Z" },
+]
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
 ]
 
 [[package]]
@@ -46,6 +59,49 @@ wheels = [
 ]
 
 [[package]]
+name = "argon2-cffi"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "argon2-cffi-bindings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/89/ce5af8a7d472a67cc819d5d998aa8c82c5d860608c4db9f46f1162d7dab9/argon2_cffi-25.1.0.tar.gz", hash = "sha256:694ae5cc8a42f4c4e2bf2ca0e64e51e23a040c6a517a85074683d3959e1346c1", size = 45706, upload-time = "2025-06-03T06:55:32.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/d3/a8b22fa575b297cd6e3e3b0155c7e25db170edf1c74783d6a31a2490b8d9/argon2_cffi-25.1.0-py3-none-any.whl", hash = "sha256:fdc8b074db390fccb6eb4a3604ae7231f219aa669a2652e0f20e16ba513d5741", size = 14657, upload-time = "2025-06-03T06:55:30.804Z" },
+]
+
+[[package]]
+name = "argon2-cffi-bindings"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/2d/db8af0df73c1cf454f71b2bbe5e356b8c1f8041c979f505b3d3186e520a9/argon2_cffi_bindings-25.1.0.tar.gz", hash = "sha256:b957f3e6ea4d55d820e40ff76f450952807013d361a65d7f28acc0acbf29229d", size = 1783441, upload-time = "2025-07-30T10:02:05.147Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/97/3c0a35f46e52108d4707c44b95cfe2afcafc50800b5450c197454569b776/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:3d3f05610594151994ca9ccb3c771115bdb4daef161976a266f0dd8aa9996b8f", size = 54393, upload-time = "2025-07-30T10:01:40.97Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f4/98bbd6ee89febd4f212696f13c03ca302b8552e7dbf9c8efa11ea4a388c3/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:8b8efee945193e667a396cbc7b4fb7d357297d6234d30a489905d96caabde56b", size = 29328, upload-time = "2025-07-30T10:01:41.916Z" },
+    { url = "https://files.pythonhosted.org/packages/43/24/90a01c0ef12ac91a6be05969f29944643bc1e5e461155ae6559befa8f00b/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3c6702abc36bf3ccba3f802b799505def420a1b7039862014a65db3205967f5a", size = 31269, upload-time = "2025-07-30T10:01:42.716Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/d3/942aa10782b2697eee7af5e12eeff5ebb325ccfb86dd8abda54174e377e4/argon2_cffi_bindings-25.1.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a1c70058c6ab1e352304ac7e3b52554daadacd8d453c1752e547c76e9c99ac44", size = 86558, upload-time = "2025-07-30T10:01:43.943Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/82/b484f702fec5536e71836fc2dbc8c5267b3f6e78d2d539b4eaa6f0db8bf8/argon2_cffi_bindings-25.1.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e2fd3bfbff3c5d74fef31a722f729bf93500910db650c925c2d6ef879a7e51cb", size = 92364, upload-time = "2025-07-30T10:01:44.887Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c1/a606ff83b3f1735f3759ad0f2cd9e038a0ad11a3de3b6c673aa41c24bb7b/argon2_cffi_bindings-25.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c4f9665de60b1b0e99bcd6be4f17d90339698ce954cfd8d9cf4f91c995165a92", size = 85637, upload-time = "2025-07-30T10:01:46.225Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b4/678503f12aceb0262f84fa201f6027ed77d71c5019ae03b399b97caa2f19/argon2_cffi_bindings-25.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ba92837e4a9aa6a508c8d2d7883ed5a8f6c308c89a4790e1e447a220deb79a85", size = 91934, upload-time = "2025-07-30T10:01:47.203Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/c7/f36bd08ef9bd9f0a9cff9428406651f5937ce27b6c5b07b92d41f91ae541/argon2_cffi_bindings-25.1.0-cp314-cp314t-win32.whl", hash = "sha256:84a461d4d84ae1295871329b346a97f68eade8c53b6ed9a7ca2d7467f3c8ff6f", size = 28158, upload-time = "2025-07-30T10:01:48.341Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/80/0106a7448abb24a2c467bf7d527fe5413b7fdfa4ad6d6a96a43a62ef3988/argon2_cffi_bindings-25.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b55aec3565b65f56455eebc9b9f34130440404f27fe21c3b375bf1ea4d8fbae6", size = 32597, upload-time = "2025-07-30T10:01:49.112Z" },
+    { url = "https://files.pythonhosted.org/packages/05/b8/d663c9caea07e9180b2cb662772865230715cbd573ba3b5e81793d580316/argon2_cffi_bindings-25.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:87c33a52407e4c41f3b70a9c2d3f6056d88b10dad7695be708c5021673f55623", size = 28231, upload-time = "2025-07-30T10:01:49.92Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/57/96b8b9f93166147826da5f90376e784a10582dd39a393c99bb62cfcf52f0/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:aecba1723ae35330a008418a91ea6cfcedf6d31e5fbaa056a166462ff066d500", size = 54121, upload-time = "2025-07-30T10:01:50.815Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/08/a9bebdb2e0e602dde230bdde8021b29f71f7841bd54801bcfd514acb5dcf/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2630b6240b495dfab90aebe159ff784d08ea999aa4b0d17efa734055a07d2f44", size = 29177, upload-time = "2025-07-30T10:01:51.681Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/02/d297943bcacf05e4f2a94ab6f462831dc20158614e5d067c35d4e63b9acb/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:7aef0c91e2c0fbca6fc68e7555aa60ef7008a739cbe045541e438373bc54d2b0", size = 31090, upload-time = "2025-07-30T10:01:53.184Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/93/44365f3d75053e53893ec6d733e4a5e3147502663554b4d864587c7828a7/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e021e87faa76ae0d413b619fe2b65ab9a037f24c60a1e6cc43457ae20de6dc6", size = 81246, upload-time = "2025-07-30T10:01:54.145Z" },
+    { url = "https://files.pythonhosted.org/packages/09/52/94108adfdd6e2ddf58be64f959a0b9c7d4ef2fa71086c38356d22dc501ea/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d3e924cfc503018a714f94a49a149fdc0b644eaead5d1f089330399134fa028a", size = 87126, upload-time = "2025-07-30T10:01:55.074Z" },
+    { url = "https://files.pythonhosted.org/packages/72/70/7a2993a12b0ffa2a9271259b79cc616e2389ed1a4d93842fac5a1f923ffd/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c87b72589133f0346a1cb8d5ecca4b933e3c9b64656c9d175270a000e73b288d", size = 80343, upload-time = "2025-07-30T10:01:56.007Z" },
+    { url = "https://files.pythonhosted.org/packages/78/9a/4e5157d893ffc712b74dbd868c7f62365618266982b64accab26bab01edc/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1db89609c06afa1a214a69a462ea741cf735b29a57530478c06eb81dd403de99", size = 86777, upload-time = "2025-07-30T10:01:56.943Z" },
+    { url = "https://files.pythonhosted.org/packages/74/cd/15777dfde1c29d96de7f18edf4cc94c385646852e7c7b0320aa91ccca583/argon2_cffi_bindings-25.1.0-cp39-abi3-win32.whl", hash = "sha256:473bcb5f82924b1becbb637b63303ec8d10e84c8d241119419897a26116515d2", size = 27180, upload-time = "2025-07-30T10:01:57.759Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c6/a759ece8f1829d1f162261226fbfd2c6832b3ff7657384045286d2afa384/argon2_cffi_bindings-25.1.0-cp39-abi3-win_amd64.whl", hash = "sha256:a98cd7d17e9f7ce244c0803cad3c23a7d379c301ba618a5fa76a67d116618b98", size = 31715, upload-time = "2025-07-30T10:01:58.56Z" },
+    { url = "https://files.pythonhosted.org/packages/42/b9/f8d6fa329ab25128b7e98fd83a3cb34d9db5b059a9847eddb840a0af45dd/argon2_cffi_bindings-25.1.0-cp39-abi3-win_arm64.whl", hash = "sha256:b0fdbcf513833809c882823f98dc2f931cf659d9a1429616ac3adebb49f5db94", size = 27149, upload-time = "2025-07-30T10:01:59.329Z" },
+]
+
+[[package]]
 name = "async-timeout"
 version = "5.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -65,14 +121,114 @@ wheels = [
 
 [[package]]
 name = "authlib"
-version = "1.6.5"
+version = "1.6.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cd/3f/1d3bbd0bf23bdd99276d4def22f29c27a914067b4cf66f753ff9b8bbd0f3/authlib-1.6.5.tar.gz", hash = "sha256:6aaf9c79b7cc96c900f0b284061691c5d4e61221640a948fe690b556a6d6d10b", size = 164553, upload-time = "2025-10-02T13:36:09.489Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/9b/b1661026ff24bc641b76b78c5222d614776b0c085bcfdac9bd15a1cb4b35/authlib-1.6.6.tar.gz", hash = "sha256:45770e8e056d0f283451d9996fbb59b70d45722b45d854d58f32878d0a40c38e", size = 164894, upload-time = "2025-12-12T08:01:41.464Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/aa/5082412d1ee302e9e7d80b6949bc4d2a8fa1149aaab610c5fc24709605d6/authlib-1.6.5-py2.py3-none-any.whl", hash = "sha256:3e0e0507807f842b02175507bdee8957a1d5707fd4afb17c32fb43fee90b6e3a", size = 243608, upload-time = "2025-10-02T13:36:07.637Z" },
+    { url = "https://files.pythonhosted.org/packages/54/51/321e821856452f7386c4e9df866f196720b1ad0c5ea1623ea7399969ae3b/authlib-1.6.6-py2.py3-none-any.whl", hash = "sha256:7d9e9bc535c13974313a87f53e8430eb6ea3d1cf6ae4f6efcd793f2e949143fd", size = 244005, upload-time = "2025-12-12T08:01:40.209Z" },
+]
+
+[[package]]
+name = "bcrypt"
+version = "5.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/36/3329e2518d70ad8e2e5817d5a4cac6bba05a47767ec416c7d020a965f408/bcrypt-5.0.0.tar.gz", hash = "sha256:f748f7c2d6fd375cc93d3fba7ef4a9e3a092421b8dbf34d8d4dc06be9492dfdd", size = 25386, upload-time = "2025-09-25T19:50:47.829Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/85/3e65e01985fddf25b64ca67275bb5bdb4040bd1a53b66d355c6c37c8a680/bcrypt-5.0.0-cp313-cp313t-macosx_10_12_universal2.whl", hash = "sha256:f3c08197f3039bec79cee59a606d62b96b16669cff3949f21e74796b6e3cd2be", size = 481806, upload-time = "2025-09-25T19:49:05.102Z" },
+    { url = "https://files.pythonhosted.org/packages/44/dc/01eb79f12b177017a726cbf78330eb0eb442fae0e7b3dfd84ea2849552f3/bcrypt-5.0.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:200af71bc25f22006f4069060c88ed36f8aa4ff7f53e67ff04d2ab3f1e79a5b2", size = 268626, upload-time = "2025-09-25T19:49:06.723Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/cf/e82388ad5959c40d6afd94fb4743cc077129d45b952d46bdc3180310e2df/bcrypt-5.0.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:baade0a5657654c2984468efb7d6c110db87ea63ef5a4b54732e7e337253e44f", size = 271853, upload-time = "2025-09-25T19:49:08.028Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/86/7134b9dae7cf0efa85671651341f6afa695857fae172615e960fb6a466fa/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:c58b56cdfb03202b3bcc9fd8daee8e8e9b6d7e3163aa97c631dfcfcc24d36c86", size = 269793, upload-time = "2025-09-25T19:49:09.727Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/82/6296688ac1b9e503d034e7d0614d56e80c5d1a08402ff856a4549cb59207/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:4bfd2a34de661f34d0bda43c3e4e79df586e4716ef401fe31ea39d69d581ef23", size = 289930, upload-time = "2025-09-25T19:49:11.204Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/18/884a44aa47f2a3b88dd09bc05a1e40b57878ecd111d17e5bba6f09f8bb77/bcrypt-5.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:ed2e1365e31fc73f1825fa830f1c8f8917ca1b3ca6185773b349c20fd606cec2", size = 272194, upload-time = "2025-09-25T19:49:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/8f/371a3ab33c6982070b674f1788e05b656cfbf5685894acbfef0c65483a59/bcrypt-5.0.0-cp313-cp313t-manylinux_2_34_aarch64.whl", hash = "sha256:83e787d7a84dbbfba6f250dd7a5efd689e935f03dd83b0f919d39349e1f23f83", size = 269381, upload-time = "2025-09-25T19:49:14.308Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/34/7e4e6abb7a8778db6422e88b1f06eb07c47682313997ee8a8f9352e5a6f1/bcrypt-5.0.0-cp313-cp313t-manylinux_2_34_x86_64.whl", hash = "sha256:137c5156524328a24b9fac1cb5db0ba618bc97d11970b39184c1d87dc4bf1746", size = 271750, upload-time = "2025-09-25T19:49:15.584Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/1b/54f416be2499bd72123c70d98d36c6cd61a4e33d9b89562c22481c81bb30/bcrypt-5.0.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:38cac74101777a6a7d3b3e3cfefa57089b5ada650dce2baf0cbdd9d65db22a9e", size = 303757, upload-time = "2025-09-25T19:49:17.244Z" },
+    { url = "https://files.pythonhosted.org/packages/13/62/062c24c7bcf9d2826a1a843d0d605c65a755bc98002923d01fd61270705a/bcrypt-5.0.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:d8d65b564ec849643d9f7ea05c6d9f0cd7ca23bdd4ac0c2dbef1104ab504543d", size = 306740, upload-time = "2025-09-25T19:49:18.693Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/c8/1fdbfc8c0f20875b6b4020f3c7dc447b8de60aa0be5faaf009d24242aec9/bcrypt-5.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:741449132f64b3524e95cd30e5cd3343006ce146088f074f31ab26b94e6c75ba", size = 334197, upload-time = "2025-09-25T19:49:20.523Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/c1/8b84545382d75bef226fbc6588af0f7b7d095f7cd6a670b42a86243183cd/bcrypt-5.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:212139484ab3207b1f0c00633d3be92fef3c5f0af17cad155679d03ff2ee1e41", size = 352974, upload-time = "2025-09-25T19:49:22.254Z" },
+    { url = "https://files.pythonhosted.org/packages/10/a6/ffb49d4254ed085e62e3e5dd05982b4393e32fe1e49bb1130186617c29cd/bcrypt-5.0.0-cp313-cp313t-win32.whl", hash = "sha256:9d52ed507c2488eddd6a95bccee4e808d3234fa78dd370e24bac65a21212b861", size = 148498, upload-time = "2025-09-25T19:49:24.134Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a9/259559edc85258b6d5fc5471a62a3299a6aa37a6611a169756bf4689323c/bcrypt-5.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f6984a24db30548fd39a44360532898c33528b74aedf81c26cf29c51ee47057e", size = 145853, upload-time = "2025-09-25T19:49:25.702Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/df/9714173403c7e8b245acf8e4be8876aac64a209d1b392af457c79e60492e/bcrypt-5.0.0-cp313-cp313t-win_arm64.whl", hash = "sha256:9fffdb387abe6aa775af36ef16f55e318dcda4194ddbf82007a6f21da29de8f5", size = 139626, upload-time = "2025-09-25T19:49:26.928Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/14/c18006f91816606a4abe294ccc5d1e6f0e42304df5a33710e9e8e95416e1/bcrypt-5.0.0-cp314-cp314t-macosx_10_12_universal2.whl", hash = "sha256:4870a52610537037adb382444fefd3706d96d663ac44cbb2f37e3919dca3d7ef", size = 481862, upload-time = "2025-09-25T19:49:28.365Z" },
+    { url = "https://files.pythonhosted.org/packages/67/49/dd074d831f00e589537e07a0725cf0e220d1f0d5d8e85ad5bbff251c45aa/bcrypt-5.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:48f753100931605686f74e27a7b49238122aa761a9aefe9373265b8b7aa43ea4", size = 268544, upload-time = "2025-09-25T19:49:30.39Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/91/50ccba088b8c474545b034a1424d05195d9fcbaaf802ab8bfe2be5a4e0d7/bcrypt-5.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f70aadb7a809305226daedf75d90379c397b094755a710d7014b8b117df1ebbf", size = 271787, upload-time = "2025-09-25T19:49:32.144Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/e7/d7dba133e02abcda3b52087a7eea8c0d4f64d3e593b4fffc10c31b7061f3/bcrypt-5.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:744d3c6b164caa658adcb72cb8cc9ad9b4b75c7db507ab4bc2480474a51989da", size = 269753, upload-time = "2025-09-25T19:49:33.885Z" },
+    { url = "https://files.pythonhosted.org/packages/33/fc/5b145673c4b8d01018307b5c2c1fc87a6f5a436f0ad56607aee389de8ee3/bcrypt-5.0.0-cp314-cp314t-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a28bc05039bdf3289d757f49d616ab3efe8cf40d8e8001ccdd621cd4f98f4fc9", size = 289587, upload-time = "2025-09-25T19:49:35.144Z" },
+    { url = "https://files.pythonhosted.org/packages/27/d7/1ff22703ec6d4f90e62f1a5654b8867ef96bafb8e8102c2288333e1a6ca6/bcrypt-5.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:7f277a4b3390ab4bebe597800a90da0edae882c6196d3038a73adf446c4f969f", size = 272178, upload-time = "2025-09-25T19:49:36.793Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/88/815b6d558a1e4d40ece04a2f84865b0fef233513bd85fd0e40c294272d62/bcrypt-5.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:79cfa161eda8d2ddf29acad370356b47f02387153b11d46042e93a0a95127493", size = 269295, upload-time = "2025-09-25T19:49:38.164Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8c/e0db387c79ab4931fc89827d37608c31cc57b6edc08ccd2386139028dc0d/bcrypt-5.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:a5393eae5722bcef046a990b84dff02b954904c36a194f6cfc817d7dca6c6f0b", size = 271700, upload-time = "2025-09-25T19:49:39.917Z" },
+    { url = "https://files.pythonhosted.org/packages/06/83/1570edddd150f572dbe9fc00f6203a89fc7d4226821f67328a85c330f239/bcrypt-5.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7f4c94dec1b5ab5d522750cb059bb9409ea8872d4494fd152b53cca99f1ddd8c", size = 334034, upload-time = "2025-09-25T19:49:41.227Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/f2/ea64e51a65e56ae7a8a4ec236c2bfbdd4b23008abd50ac33fbb2d1d15424/bcrypt-5.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0cae4cb350934dfd74c020525eeae0a5f79257e8a201c0c176f4b84fdbf2a4b4", size = 352766, upload-time = "2025-09-25T19:49:43.08Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/d4/1a388d21ee66876f27d1a1f41287897d0c0f1712ef97d395d708ba93004c/bcrypt-5.0.0-cp314-cp314t-win32.whl", hash = "sha256:b17366316c654e1ad0306a6858e189fc835eca39f7eb2cafd6aaca8ce0c40a2e", size = 152449, upload-time = "2025-09-25T19:49:44.971Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/61/3291c2243ae0229e5bca5d19f4032cecad5dfb05a2557169d3a69dc0ba91/bcrypt-5.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:92864f54fb48b4c718fc92a32825d0e42265a627f956bc0361fe869f1adc3e7d", size = 149310, upload-time = "2025-09-25T19:49:46.162Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/89/4b01c52ae0c1a681d4021e5dd3e45b111a8fb47254a274fa9a378d8d834b/bcrypt-5.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dd19cf5184a90c873009244586396a6a884d591a5323f0e8a5922560718d4993", size = 143761, upload-time = "2025-09-25T19:49:47.345Z" },
+    { url = "https://files.pythonhosted.org/packages/84/29/6237f151fbfe295fe3e074ecc6d44228faa1e842a81f6d34a02937ee1736/bcrypt-5.0.0-cp38-abi3-macosx_10_12_universal2.whl", hash = "sha256:fc746432b951e92b58317af8e0ca746efe93e66555f1b40888865ef5bf56446b", size = 494553, upload-time = "2025-09-25T19:49:49.006Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b6/4c1205dde5e464ea3bd88e8742e19f899c16fa8916fb8510a851fae985b5/bcrypt-5.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c2388ca94ffee269b6038d48747f4ce8df0ffbea43f31abfa18ac72f0218effb", size = 275009, upload-time = "2025-09-25T19:49:50.581Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/71/427945e6ead72ccffe77894b2655b695ccf14ae1866cd977e185d606dd2f/bcrypt-5.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:560ddb6ec730386e7b3b26b8b4c88197aaed924430e7b74666a586ac997249ef", size = 278029, upload-time = "2025-09-25T19:49:52.533Z" },
+    { url = "https://files.pythonhosted.org/packages/17/72/c344825e3b83c5389a369c8a8e58ffe1480b8a699f46c127c34580c4666b/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d79e5c65dcc9af213594d6f7f1fa2c98ad3fc10431e7aa53c176b441943efbdd", size = 275907, upload-time = "2025-09-25T19:49:54.709Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/7e/d4e47d2df1641a36d1212e5c0514f5291e1a956a7749f1e595c07a972038/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2b732e7d388fa22d48920baa267ba5d97cca38070b69c0e2d37087b381c681fd", size = 296500, upload-time = "2025-09-25T19:49:56.013Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/c3/0ae57a68be2039287ec28bc463b82e4b8dc23f9d12c0be331f4782e19108/bcrypt-5.0.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0c8e093ea2532601a6f686edbc2c6b2ec24131ff5c52f7610dd64fa4553b5464", size = 278412, upload-time = "2025-09-25T19:49:57.356Z" },
+    { url = "https://files.pythonhosted.org/packages/45/2b/77424511adb11e6a99e3a00dcc7745034bee89036ad7d7e255a7e47be7d8/bcrypt-5.0.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5b1589f4839a0899c146e8892efe320c0fa096568abd9b95593efac50a87cb75", size = 275486, upload-time = "2025-09-25T19:49:59.116Z" },
+    { url = "https://files.pythonhosted.org/packages/43/0a/405c753f6158e0f3f14b00b462d8bca31296f7ecfc8fc8bc7919c0c7d73a/bcrypt-5.0.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:89042e61b5e808b67daf24a434d89bab164d4de1746b37a8d173b6b14f3db9ff", size = 277940, upload-time = "2025-09-25T19:50:00.869Z" },
+    { url = "https://files.pythonhosted.org/packages/62/83/b3efc285d4aadc1fa83db385ec64dcfa1707e890eb42f03b127d66ac1b7b/bcrypt-5.0.0-cp38-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:e3cf5b2560c7b5a142286f69bde914494b6d8f901aaa71e453078388a50881c4", size = 310776, upload-time = "2025-09-25T19:50:02.393Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7d/47ee337dacecde6d234890fe929936cb03ebc4c3a7460854bbd9c97780b8/bcrypt-5.0.0-cp38-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:f632fd56fc4e61564f78b46a2269153122db34988e78b6be8b32d28507b7eaeb", size = 312922, upload-time = "2025-09-25T19:50:04.232Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/3a/43d494dfb728f55f4e1cf8fd435d50c16a2d75493225b54c8d06122523c6/bcrypt-5.0.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:801cad5ccb6b87d1b430f183269b94c24f248dddbbc5c1f78b6ed231743e001c", size = 341367, upload-time = "2025-09-25T19:50:05.559Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ab/a0727a4547e383e2e22a630e0f908113db37904f58719dc48d4622139b5c/bcrypt-5.0.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3cf67a804fc66fc217e6914a5635000259fbbbb12e78a99488e4d5ba445a71eb", size = 359187, upload-time = "2025-09-25T19:50:06.916Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/bb/461f352fdca663524b4643d8b09e8435b4990f17fbf4fea6bc2a90aa0cc7/bcrypt-5.0.0-cp38-abi3-win32.whl", hash = "sha256:3abeb543874b2c0524ff40c57a4e14e5d3a66ff33fb423529c88f180fd756538", size = 153752, upload-time = "2025-09-25T19:50:08.515Z" },
+    { url = "https://files.pythonhosted.org/packages/41/aa/4190e60921927b7056820291f56fc57d00d04757c8b316b2d3c0d1d6da2c/bcrypt-5.0.0-cp38-abi3-win_amd64.whl", hash = "sha256:35a77ec55b541e5e583eb3436ffbbf53b0ffa1fa16ca6782279daf95d146dcd9", size = 150881, upload-time = "2025-09-25T19:50:09.742Z" },
+    { url = "https://files.pythonhosted.org/packages/54/12/cd77221719d0b39ac0b55dbd39358db1cd1246e0282e104366ebbfb8266a/bcrypt-5.0.0-cp38-abi3-win_arm64.whl", hash = "sha256:cde08734f12c6a4e28dc6755cd11d3bdfea608d93d958fffbe95a7026ebe4980", size = 144931, upload-time = "2025-09-25T19:50:11.016Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ba/2af136406e1c3839aea9ecadc2f6be2bcd1eff255bd451dd39bcf302c47a/bcrypt-5.0.0-cp39-abi3-macosx_10_12_universal2.whl", hash = "sha256:0c418ca99fd47e9c59a301744d63328f17798b5947b0f791e9af3c1c499c2d0a", size = 495313, upload-time = "2025-09-25T19:50:12.309Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ee/2f4985dbad090ace5ad1f7dd8ff94477fe089b5fab2040bd784a3d5f187b/bcrypt-5.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddb4e1500f6efdd402218ffe34d040a1196c072e07929b9820f363a1fd1f4191", size = 275290, upload-time = "2025-09-25T19:50:13.673Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/6e/b77ade812672d15cf50842e167eead80ac3514f3beacac8902915417f8b7/bcrypt-5.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7aeef54b60ceddb6f30ee3db090351ecf0d40ec6e2abf41430997407a46d2254", size = 278253, upload-time = "2025-09-25T19:50:15.089Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c4/ed00ed32f1040f7990dac7115f82273e3c03da1e1a1587a778d8cea496d8/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:f0ce778135f60799d89c9693b9b398819d15f1921ba15fe719acb3178215a7db", size = 276084, upload-time = "2025-09-25T19:50:16.699Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/c4/fa6e16145e145e87f1fa351bbd54b429354fd72145cd3d4e0c5157cf4c70/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a71f70ee269671460b37a449f5ff26982a6f2ba493b3eabdd687b4bf35f875ac", size = 297185, upload-time = "2025-09-25T19:50:18.525Z" },
+    { url = "https://files.pythonhosted.org/packages/24/b4/11f8a31d8b67cca3371e046db49baa7c0594d71eb40ac8121e2fc0888db0/bcrypt-5.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f8429e1c410b4073944f03bd778a9e066e7fad723564a52ff91841d278dfc822", size = 278656, upload-time = "2025-09-25T19:50:19.809Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/31/79f11865f8078e192847d2cb526e3fa27c200933c982c5b2869720fa5fce/bcrypt-5.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:edfcdcedd0d0f05850c52ba3127b1fce70b9f89e0fe5ff16517df7e81fa3cbb8", size = 275662, upload-time = "2025-09-25T19:50:21.567Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/8d/5e43d9584b3b3591a6f9b68f755a4da879a59712981ef5ad2a0ac1379f7a/bcrypt-5.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:611f0a17aa4a25a69362dcc299fda5c8a3d4f160e2abb3831041feb77393a14a", size = 278240, upload-time = "2025-09-25T19:50:23.305Z" },
+    { url = "https://files.pythonhosted.org/packages/89/48/44590e3fc158620f680a978aafe8f87a4c4320da81ed11552f0323aa9a57/bcrypt-5.0.0-cp39-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:db99dca3b1fdc3db87d7c57eac0c82281242d1eabf19dcb8a6b10eb29a2e72d1", size = 311152, upload-time = "2025-09-25T19:50:24.597Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/85/e4fbfc46f14f47b0d20493669a625da5827d07e8a88ee460af6cd9768b44/bcrypt-5.0.0-cp39-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:5feebf85a9cefda32966d8171f5db7e3ba964b77fdfe31919622256f80f9cf42", size = 313284, upload-time = "2025-09-25T19:50:26.268Z" },
+    { url = "https://files.pythonhosted.org/packages/25/ae/479f81d3f4594456a01ea2f05b132a519eff9ab5768a70430fa1132384b1/bcrypt-5.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:3ca8a166b1140436e058298a34d88032ab62f15aae1c598580333dc21d27ef10", size = 341643, upload-time = "2025-09-25T19:50:28.02Z" },
+    { url = "https://files.pythonhosted.org/packages/df/d2/36a086dee1473b14276cd6ea7f61aef3b2648710b5d7f1c9e032c29b859f/bcrypt-5.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:61afc381250c3182d9078551e3ac3a41da14154fbff647ddf52a769f588c4172", size = 359698, upload-time = "2025-09-25T19:50:31.347Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/f6/688d2cd64bfd0b14d805ddb8a565e11ca1fb0fd6817175d58b10052b6d88/bcrypt-5.0.0-cp39-abi3-win32.whl", hash = "sha256:64d7ce196203e468c457c37ec22390f1a61c85c6f0b8160fd752940ccfb3a683", size = 153725, upload-time = "2025-09-25T19:50:34.384Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/b9/9d9a641194a730bda138b3dfe53f584d61c58cd5230e37566e83ec2ffa0d/bcrypt-5.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:64ee8434b0da054d830fa8e89e1c8bf30061d539044a39524ff7dec90481e5c2", size = 150912, upload-time = "2025-09-25T19:50:35.69Z" },
+    { url = "https://files.pythonhosted.org/packages/27/44/d2ef5e87509158ad2187f4dd0852df80695bb1ee0cfe0a684727b01a69e0/bcrypt-5.0.0-cp39-abi3-win_arm64.whl", hash = "sha256:f2347d3534e76bf50bca5500989d6c1d05ed64b440408057a37673282c654927", size = 144953, upload-time = "2025-09-25T19:50:37.32Z" },
+]
+
+[[package]]
+name = "beartype"
+version = "0.22.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/94/1009e248bbfbab11397abca7193bea6626806be9a327d399810d523a07cb/beartype-0.22.9.tar.gz", hash = "sha256:8f82b54aa723a2848a56008d18875f91c1db02c32ef6a62319a002e3e25a975f", size = 1608866, upload-time = "2025-12-13T06:50:30.72Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl", hash = "sha256:d16c9bbc61ea14637596c5f6fbff2ee99cbe3573e46a716401734ef50c3060c2", size = 1333658, upload-time = "2025-12-13T06:50:28.266Z" },
+]
+
+[[package]]
+name = "burner-redis"
+version = "0.1.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/89/54706febafc135095b2a9d797cfbd4eed2ab1ad7819808b99b587020471b/burner_redis-0.1.7.tar.gz", hash = "sha256:7474ff092669fd11ef765411572cdafcc3d89b8054aef4ca0617be6d6be4c680", size = 638644, upload-time = "2026-05-08T15:01:42.961Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/5d/198bd1d22e504b3034353430703afbdb3efe6e25cb90bf52d896e1d266a7/burner_redis-0.1.7-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:f80c866996e0455d584eb3c0f3b067e411c632fb0519eab454e0968edf01e62c", size = 1288888, upload-time = "2026-05-08T15:01:26.103Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/4e/ce5c91b884ac37fcd380756402536f8810964014097950900517ce8bd30c/burner_redis-0.1.7-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:a3d9569a376b690fb5876d454e4904443332dc3ad5c0057e149fc2ad220bf599", size = 1234282, upload-time = "2026-05-08T15:01:28.286Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/31c25cc88143eac2dddcc394151a0db627923d44c94376a83768552c9f13/burner_redis-0.1.7-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:20eba1917e3bca9eea5957d5700ff8defcb5a209e57a7841d005549aa0151f44", size = 1337341, upload-time = "2026-05-08T15:01:30.397Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/32/95cfa1833316ca2b6b2e58150a4900bc1ad256043cdd36198f1887618ccc/burner_redis-0.1.7-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39111467059b8a28f15ea061d2414ec25c3e57c65759983f90f4d358e7d6a72d", size = 1366800, upload-time = "2026-05-08T15:01:32.891Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ad/93c3916f053f89b7b5760da5bf855cd78b7885d480f9cfcc64f3732c1dc2/burner_redis-0.1.7-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9b5adfe99aeb8407f468078f3769b2a63e9168fea12f7709df5d2a3b152706e4", size = 1538160, upload-time = "2026-05-08T15:01:34.667Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/b9/19bae42cb124932d71168bc8e5bcb1da33aa62b908e5e632b3d298d7cb15/burner_redis-0.1.7-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:591a9d20685f9d6d22bf0c863b50b12dfcf328b06111b3f62c33cd3185d48ce0", size = 1591491, upload-time = "2026-05-08T15:01:36.708Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/30/207f47f406619a5b564355d2946c3171f84231a28b800709b5645b06a5ae/burner_redis-0.1.7-cp310-abi3-win_amd64.whl", hash = "sha256:f6cf4ac666766b32fd63940aad0c120847905fd3102c17e5b6b305f91a21d079", size = 1117564, upload-time = "2026-05-08T15:01:39.221Z" },
+    { url = "https://files.pythonhosted.org/packages/76/6f/e9beaf46c5e9fd10dfcdb889ebf7d3aa85142c650c0ab17ab284194f58e1/burner_redis-0.1.7-cp310-abi3-win_arm64.whl", hash = "sha256:458f88feeddfb40a586cc3fcbd8e9384bbdfd2a4512a695af4900e06052570d4", size = 1040407, upload-time = "2026-05-08T15:01:41.235Z" },
+]
+
+[[package]]
+name = "cachetools"
+version = "7.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/8b/0d3945a13955303b81272f759a0331e54c5c793da455e6f5706b89d2639c/cachetools-7.1.4.tar.gz", hash = "sha256:437f55a4e0c1b01a4f3077cc470e6991d47430970e36fbcb77e2be0df4fc1cd6", size = 40085, upload-time = "2026-05-21T22:40:43.376Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/7b/1fc1c09cc0756cf25861a3be10565915953876da48bb228fb9a672b20a42/cachetools-7.1.4-py3-none-any.whl", hash = "sha256:323dc4127934744db5b54eb4924482d7edafbf9554e820d1531c2e08c0e4ef54", size = 16761, upload-time = "2026-05-21T22:40:41.845Z" },
 ]
 
 [[package]]
@@ -183,12 +339,29 @@ wheels = [
 ]
 
 [[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "cronsim"
+version = "2.7"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/1a/02f105147f7f2e06ed4f734ff5a6439590bb275a53dd91fc73df6312298a/cronsim-2.7-py3-none-any.whl", hash = "sha256:1e1431fa08c51dc7f72e67e571c7c7a09af26420169b607badd4ca9677ffad1e", size = 14213, upload-time = "2025-10-21T16:38:20.431Z" },
 ]
 
 [[package]]
@@ -263,6 +436,15 @@ wheels = [
 ]
 
 [[package]]
+name = "diskcache"
+version = "5.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/21/1c1ffc1a039ddcc459db43cc108658f32c57d271d7289a2794e401d0fdb6/diskcache-5.6.3.tar.gz", hash = "sha256:2c3a3fa2743d8535d832ec61c2054a1641f41775aa7c556758a109941e33e4fc", size = 67916, upload-time = "2023-08-31T06:12:00.316Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/27/4570e78fc0bf5ea0ca45eb1de3818a23787af9b390c0b0a0033a1b8236f9/diskcache-5.6.3-py3-none-any.whl", hash = "sha256:5e31b2d5fbad117cc363ebaf6b689474db18a1f6438bc82358b024abd4c2ca19", size = 45550, upload-time = "2023-08-31T06:11:58.822Z" },
+]
+
+[[package]]
 name = "dnspython"
 version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -327,38 +509,46 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.119.0"
+version = "0.128.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "annotated-doc" },
     { name = "pydantic" },
     { name = "starlette" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0a/f9/5c5bcce82a7997cc0eb8c47b7800f862f6b56adc40486ed246e5010d443b/fastapi-0.119.0.tar.gz", hash = "sha256:451082403a2c1f0b99c6bd57c09110ed5463856804c8078d38e5a1f1035dbbb7", size = 336756, upload-time = "2025-10-11T17:13:40.53Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/08/8c8508db6c7b9aae8f7175046af41baad690771c9bcde676419965e338c7/fastapi-0.128.0.tar.gz", hash = "sha256:1cc179e1cef10a6be60ffe429f79b829dce99d8de32d7acb7e6c8dfdf7f2645a", size = 365682, upload-time = "2025-12-27T15:21:13.714Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/70/584c4d7cad80f5e833715c0a29962d7c93b4d18eed522a02981a6d1b6ee5/fastapi-0.119.0-py3-none-any.whl", hash = "sha256:90a2e49ed19515320abb864df570dd766be0662c5d577688f1600170f7f73cf2", size = 107095, upload-time = "2025-10-11T17:13:39.048Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5cbb59154b093548acd0f4c7c474a118eda06da25aa75c616b72d8fcd92a/fastapi-0.128.0-py3-none-any.whl", hash = "sha256:aebd93f9716ee3b4f4fcfe13ffb7cf308d99c9f3ab5622d8877441072561582d", size = 103094, upload-time = "2025-12-27T15:21:12.154Z" },
 ]
 
 [[package]]
 name = "fastmcp"
-version = "2.12.4"
+version = "2.14.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
     { name = "cyclopts" },
     { name = "exceptiongroup" },
     { name = "httpx" },
+    { name = "jsonref" },
+    { name = "jsonschema-path" },
     { name = "mcp" },
-    { name = "openapi-core" },
     { name = "openapi-pydantic" },
+    { name = "packaging" },
+    { name = "platformdirs" },
+    { name = "py-key-value-aio", extra = ["disk", "keyring", "memory"] },
     { name = "pydantic", extra = ["email"] },
+    { name = "pydocket" },
     { name = "pyperclip" },
     { name = "python-dotenv" },
     { name = "rich" },
+    { name = "uvicorn" },
+    { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a8/b2/57845353a9bc63002995a982e66f3d0be4ec761e7bcb89e7d0638518d42a/fastmcp-2.12.4.tar.gz", hash = "sha256:b55fe89537038f19d0f4476544f9ca5ac171033f61811cc8f12bdeadcbea5016", size = 7167745, upload-time = "2025-09-26T16:43:27.71Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/32/982678d44f13849530a74ab101ed80e060c2ee6cf87471f062dcf61705fd/fastmcp-2.14.5.tar.gz", hash = "sha256:38944dc582c541d55357082bda2241cedb42cd3a78faea8a9d6a2662c62a42d7", size = 8296329, upload-time = "2026-02-03T15:35:21.005Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/c7/562ff39f25de27caec01e4c1e88cbb5fcae5160802ba3d90be33165df24f/fastmcp-2.12.4-py3-none-any.whl", hash = "sha256:56188fbbc1a9df58c537063f25958c57b5c4d715f73e395c41b51550b247d140", size = 329090, upload-time = "2025-09-26T16:43:25.314Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/c1/1a35ec68ff76ea8443aa115b18bcdee748a4ada2124537ee90522899ff9f/fastmcp-2.14.5-py3-none-any.whl", hash = "sha256:d81e8ec813f5089d3624bec93944beaefa86c0c3a4ef1111cbef676a761ebccf", size = 417784, upload-time = "2026-02-03T15:35:18.489Z" },
 ]
 
 [[package]]
@@ -444,6 +634,48 @@ wheels = [
 ]
 
 [[package]]
+name = "jaraco-classes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777, upload-time = "2024-03-31T07:27:34.792Z" },
+]
+
+[[package]]
+name = "jaraco-context"
+version = "6.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/50/4763cd07e722bb6285316d390a164bc7e479db9d90daa769f22578f698b4/jaraco_context-6.1.2.tar.gz", hash = "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3", size = 16801, upload-time = "2026-03-20T22:13:33.922Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl", hash = "sha256:bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535", size = 7871, upload-time = "2026-03-20T22:13:32.808Z" },
+]
+
+[[package]]
+name = "jaraco-functools"
+version = "4.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6c/1f/c23395957d41ccf27c4e535c3d334c4051e5395b3752057ba4cbaec35c56/jaraco_functools-4.6.0.tar.gz", hash = "sha256:880c577ec9720b3a052d5bc611fb9f2269b3d87902ef42440df443b88e443280", size = 20837, upload-time = "2026-07-14T01:28:02.544Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/36/ecc85bc96c273dc8a11273ed4782272975e6338d4a3e9228621175edf0e3/jaraco_functools-4.6.0-py3-none-any.whl", hash = "sha256:99e3dc0060c5cbe8fcd1cdb36258e2a65ca40f1566b2033b12abb1bb44dd3c30", size = 11677, upload-time = "2026-07-14T01:28:01.59Z" },
+]
+
+[[package]]
+name = "jeepney"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
+]
+
+[[package]]
 name = "js"
 version = "1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -452,6 +684,15 @@ dependencies = [
     { name = "setuptools" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c0/ec/93bb7175ffcfb86eb9d46ae25fa6097b2e853caa362e3e38de8ab4e5eda1/js-1.0.tar.gz", hash = "sha256:9bade58e82ec88443ad9dd375674ef0d9597dfa6c773897e9019ebedc54d1f00", size = 2523, upload-time = "2012-08-22T04:58:59.132Z" }
+
+[[package]]
+name = "jsonref"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/0d/c1f3277e90ccdb50d33ed5ba1ec5b3f0a242ed8c1b1a85d3afeb68464dca/jsonref-1.1.0.tar.gz", hash = "sha256:32fe8e1d85af0fdefbebce950af85590b22b60f9e95443176adbde4e1ecea552", size = 8814, upload-time = "2023-01-16T16:10:04.455Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/ec/e1db9922bceb168197a558a2b8c03a7963f1afe93517ddd3cf99f202f996/jsonref-1.1.0-py3-none-any.whl", hash = "sha256:590dc7773df6c21cbf948b5dac07a72a251db28b0238ceecce0a2abfa8ec30a9", size = 9425, upload-time = "2023-01-16T16:10:02.255Z" },
+]
 
 [[package]]
 name = "jsonschema"
@@ -496,29 +737,20 @@ wheels = [
 ]
 
 [[package]]
-name = "lazy-object-proxy"
-version = "1.12.0"
+name = "keyring"
+version = "25.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/08/a2/69df9c6ba6d316cfd81fe2381e464db3e6de5db45f8c43c6a23504abf8cb/lazy_object_proxy-1.12.0.tar.gz", hash = "sha256:1f5a462d92fd0cfb82f1fab28b51bfb209fabbe6aabf7f0d51472c0c124c0c61", size = 43681, upload-time = "2025-08-22T13:50:06.783Z" }
+dependencies = [
+    { name = "jaraco-classes" },
+    { name = "jaraco-context" },
+    { name = "jaraco-functools" },
+    { name = "jeepney", marker = "sys_platform == 'linux'" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "secretstorage", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/26/b74c791008841f8ad896c7f293415136c66cc27e7c7577de4ee68040c110/lazy_object_proxy-1.12.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:86fd61cb2ba249b9f436d789d1356deae69ad3231dc3c0f17293ac535162672e", size = 26745, upload-time = "2025-08-22T13:42:44.982Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/52/641870d309e5d1fb1ea7d462a818ca727e43bfa431d8c34b173eb090348c/lazy_object_proxy-1.12.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:81d1852fb30fab81696f93db1b1e55a5d1ff7940838191062f5f56987d5fcc3e", size = 71537, upload-time = "2025-08-22T13:42:46.141Z" },
-    { url = "https://files.pythonhosted.org/packages/47/b6/919118e99d51c5e76e8bf5a27df406884921c0acf2c7b8a3b38d847ab3e9/lazy_object_proxy-1.12.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:be9045646d83f6c2664c1330904b245ae2371b5c57a3195e4028aedc9f999655", size = 71141, upload-time = "2025-08-22T13:42:47.375Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/47/1d20e626567b41de085cf4d4fb3661a56c159feaa73c825917b3b4d4f806/lazy_object_proxy-1.12.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:67f07ab742f1adfb3966c40f630baaa7902be4222a17941f3d85fd1dae5565ff", size = 69449, upload-time = "2025-08-22T13:42:48.49Z" },
-    { url = "https://files.pythonhosted.org/packages/58/8d/25c20ff1a1a8426d9af2d0b6f29f6388005fc8cd10d6ee71f48bff86fdd0/lazy_object_proxy-1.12.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:75ba769017b944fcacbf6a80c18b2761a1795b03f8899acdad1f1c39db4409be", size = 70744, upload-time = "2025-08-22T13:42:49.608Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/67/8ec9abe15c4f8a4bcc6e65160a2c667240d025cbb6591b879bea55625263/lazy_object_proxy-1.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:7b22c2bbfb155706b928ac4d74c1a63ac8552a55ba7fff4445155523ea4067e1", size = 26568, upload-time = "2025-08-22T13:42:57.719Z" },
-    { url = "https://files.pythonhosted.org/packages/23/12/cd2235463f3469fd6c62d41d92b7f120e8134f76e52421413a0ad16d493e/lazy_object_proxy-1.12.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4a79b909aa16bde8ae606f06e6bbc9d3219d2e57fb3e0076e17879072b742c65", size = 27391, upload-time = "2025-08-22T13:42:50.62Z" },
-    { url = "https://files.pythonhosted.org/packages/60/9e/f1c53e39bbebad2e8609c67d0830cc275f694d0ea23d78e8f6db526c12d3/lazy_object_proxy-1.12.0-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:338ab2f132276203e404951205fe80c3fd59429b3a724e7b662b2eb539bb1be9", size = 80552, upload-time = "2025-08-22T13:42:51.731Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/b6/6c513693448dcb317d9d8c91d91f47addc09553613379e504435b4cc8b3e/lazy_object_proxy-1.12.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8c40b3c9faee2e32bfce0df4ae63f4e73529766893258eca78548bac801c8f66", size = 82857, upload-time = "2025-08-22T13:42:53.225Z" },
-    { url = "https://files.pythonhosted.org/packages/12/1c/d9c4aaa4c75da11eb7c22c43d7c90a53b4fca0e27784a5ab207768debea7/lazy_object_proxy-1.12.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:717484c309df78cedf48396e420fa57fc8a2b1f06ea889df7248fdd156e58847", size = 80833, upload-time = "2025-08-22T13:42:54.391Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/ae/29117275aac7d7d78ae4f5a4787f36ff33262499d486ac0bf3e0b97889f6/lazy_object_proxy-1.12.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a6b7ea5ea1ffe15059eb44bcbcb258f97bcb40e139b88152c40d07b1a1dfc9ac", size = 79516, upload-time = "2025-08-22T13:42:55.812Z" },
-    { url = "https://files.pythonhosted.org/packages/19/40/b4e48b2c38c69392ae702ae7afa7b6551e0ca5d38263198b7c79de8b3bdf/lazy_object_proxy-1.12.0-cp313-cp313t-win_amd64.whl", hash = "sha256:08c465fb5cd23527512f9bd7b4c7ba6cec33e28aad36fbbe46bf7b858f9f3f7f", size = 27656, upload-time = "2025-08-22T13:42:56.793Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/3a/277857b51ae419a1574557c0b12e0d06bf327b758ba94cafc664cb1e2f66/lazy_object_proxy-1.12.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c9defba70ab943f1df98a656247966d7729da2fe9c2d5d85346464bf320820a3", size = 26582, upload-time = "2025-08-22T13:49:49.366Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/b6/c5e0fa43535bb9c87880e0ba037cdb1c50e01850b0831e80eb4f4762f270/lazy_object_proxy-1.12.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6763941dbf97eea6b90f5b06eb4da9418cc088fce0e3883f5816090f9afcde4a", size = 71059, upload-time = "2025-08-22T13:49:50.488Z" },
-    { url = "https://files.pythonhosted.org/packages/06/8a/7dcad19c685963c652624702f1a968ff10220b16bfcc442257038216bf55/lazy_object_proxy-1.12.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fdc70d81235fc586b9e3d1aeef7d1553259b62ecaae9db2167a5d2550dcc391a", size = 71034, upload-time = "2025-08-22T13:49:54.224Z" },
-    { url = "https://files.pythonhosted.org/packages/12/ac/34cbfb433a10e28c7fd830f91c5a348462ba748413cbb950c7f259e67aa7/lazy_object_proxy-1.12.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0a83c6f7a6b2bfc11ef3ed67f8cbe99f8ff500b05655d8e7df9aab993a6abc95", size = 69529, upload-time = "2025-08-22T13:49:55.29Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/6a/11ad7e349307c3ca4c0175db7a77d60ce42a41c60bcb11800aabd6a8acb8/lazy_object_proxy-1.12.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:256262384ebd2a77b023ad02fbcc9326282bcfd16484d5531154b02bc304f4c5", size = 70391, upload-time = "2025-08-22T13:49:56.35Z" },
-    { url = "https://files.pythonhosted.org/packages/59/97/9b410ed8fbc6e79c1ee8b13f8777a80137d4bc189caf2c6202358e66192c/lazy_object_proxy-1.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:7601ec171c7e8584f8ff3f4e440aa2eebf93e854f04639263875b8c2971f819f", size = 26988, upload-time = "2025-08-22T13:49:57.302Z" },
+    { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload-time = "2025-11-16T16:26:08.402Z" },
 ]
 
 [[package]]
@@ -606,35 +838,59 @@ wheels = [
 
 [[package]]
 name = "markupsafe"
-version = "3.0.2"
+version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b2/97/5d42485e71dfc078108a86d6de8fa46db44a1a9295e89c5d6d4a06e23a62/markupsafe-3.0.2.tar.gz", hash = "sha256:ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0", size = 20537, upload-time = "2024-10-18T15:21:54.129Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/0e/67eb10a7ecc77a0c2bbe2b0235765b98d164d81600746914bebada795e97/MarkupSafe-3.0.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ba9527cdd4c926ed0760bc301f6728ef34d841f405abf9d4f959c478421e4efd", size = 14274, upload-time = "2024-10-18T15:21:24.577Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/6d/9409f3684d3335375d04e5f05744dfe7e9f120062c9857df4ab490a1031a/MarkupSafe-3.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f8b3d067f2e40fe93e1ccdd6b2e1d16c43140e76f02fb1319a05cf2b79d99430", size = 12352, upload-time = "2024-10-18T15:21:25.382Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/f5/6eadfcd3885ea85fe2a7c128315cc1bb7241e1987443d78c8fe712d03091/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:569511d3b58c8791ab4c2e1285575265991e6d8f8700c7be0e88f86cb0672094", size = 24122, upload-time = "2024-10-18T15:21:26.199Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/91/96cf928db8236f1bfab6ce15ad070dfdd02ed88261c2afafd4b43575e9e9/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:15ab75ef81add55874e7ab7055e9c397312385bd9ced94920f2802310c930396", size = 23085, upload-time = "2024-10-18T15:21:27.029Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/cf/c9d56af24d56ea04daae7ac0940232d31d5a8354f2b457c6d856b2057d69/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f3818cb119498c0678015754eba762e0d61e5b52d34c8b13d770f0719f7b1d79", size = 22978, upload-time = "2024-10-18T15:21:27.846Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/9f/8619835cd6a711d6272d62abb78c033bda638fdc54c4e7f4272cf1c0962b/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cdb82a876c47801bb54a690c5ae105a46b392ac6099881cdfb9f6e95e4014c6a", size = 24208, upload-time = "2024-10-18T15:21:28.744Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/bf/176950a1792b2cd2102b8ffeb5133e1ed984547b75db47c25a67d3359f77/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:cabc348d87e913db6ab4aa100f01b08f481097838bdddf7c7a84b7575b7309ca", size = 23357, upload-time = "2024-10-18T15:21:29.545Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/4f/9a02c1d335caabe5c4efb90e1b6e8ee944aa245c1aaaab8e8a618987d816/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:444dcda765c8a838eaae23112db52f1efaf750daddb2d9ca300bcae1039adc5c", size = 23344, upload-time = "2024-10-18T15:21:30.366Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/55/c271b57db36f748f0e04a759ace9f8f759ccf22b4960c270c78a394f58be/MarkupSafe-3.0.2-cp313-cp313-win32.whl", hash = "sha256:bcf3e58998965654fdaff38e58584d8937aa3096ab5354d493c77d1fdd66d7a1", size = 15101, upload-time = "2024-10-18T15:21:31.207Z" },
-    { url = "https://files.pythonhosted.org/packages/29/88/07df22d2dd4df40aba9f3e402e6dc1b8ee86297dddbad4872bd5e7b0094f/MarkupSafe-3.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:e6a2a455bd412959b57a172ce6328d2dd1f01cb2135efda2e4576e8a23fa3b0f", size = 15603, upload-time = "2024-10-18T15:21:32.032Z" },
-    { url = "https://files.pythonhosted.org/packages/62/6a/8b89d24db2d32d433dffcd6a8779159da109842434f1dd2f6e71f32f738c/MarkupSafe-3.0.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:b5a6b3ada725cea8a5e634536b1b01c30bcdcd7f9c6fff4151548d5bf6b3a36c", size = 14510, upload-time = "2024-10-18T15:21:33.625Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/06/a10f955f70a2e5a9bf78d11a161029d278eeacbd35ef806c3fd17b13060d/MarkupSafe-3.0.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a904af0a6162c73e3edcb969eeeb53a63ceeb5d8cf642fade7d39e7963a22ddb", size = 12486, upload-time = "2024-10-18T15:21:34.611Z" },
-    { url = "https://files.pythonhosted.org/packages/34/cf/65d4a571869a1a9078198ca28f39fba5fbb910f952f9dbc5220afff9f5e6/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4aa4e5faecf353ed117801a068ebab7b7e09ffb6e1d5e412dc852e0da018126c", size = 25480, upload-time = "2024-10-18T15:21:35.398Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/e3/90e9651924c430b885468b56b3d597cabf6d72be4b24a0acd1fa0e12af67/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c0ef13eaeee5b615fb07c9a7dadb38eac06a0608b41570d8ade51c56539e509d", size = 23914, upload-time = "2024-10-18T15:21:36.231Z" },
-    { url = "https://files.pythonhosted.org/packages/66/8c/6c7cf61f95d63bb866db39085150df1f2a5bd3335298f14a66b48e92659c/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d16a81a06776313e817c951135cf7340a3e91e8c1ff2fac444cfd75fffa04afe", size = 23796, upload-time = "2024-10-18T15:21:37.073Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/35/cbe9238ec3f47ac9a7c8b3df7a808e7cb50fe149dc7039f5f454b3fba218/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6381026f158fdb7c72a168278597a5e3a5222e83ea18f543112b2662a9b699c5", size = 25473, upload-time = "2024-10-18T15:21:37.932Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/32/7621a4382488aa283cc05e8984a9c219abad3bca087be9ec77e89939ded9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:3d79d162e7be8f996986c064d1c7c817f6df3a77fe3d6859f6f9e7be4b8c213a", size = 24114, upload-time = "2024-10-18T15:21:39.799Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/80/0985960e4b89922cb5a0bac0ed39c5b96cbc1a536a99f30e8c220a996ed9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:131a3c7689c85f5ad20f9f6fb1b866f402c445b220c19fe4308c0b147ccd2ad9", size = 24098, upload-time = "2024-10-18T15:21:40.813Z" },
-    { url = "https://files.pythonhosted.org/packages/82/78/fedb03c7d5380df2427038ec8d973587e90561b2d90cd472ce9254cf348b/MarkupSafe-3.0.2-cp313-cp313t-win32.whl", hash = "sha256:ba8062ed2cf21c07a9e295d5b8a2a5ce678b913b45fdf68c32d95d6c1291e0b6", size = 15208, upload-time = "2024-10-18T15:21:41.814Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/65/6079a46068dfceaeabb5dcad6d674f5f5c61a6fa5673746f42a9f4c233b3/MarkupSafe-3.0.2-cp313-cp313t-win_amd64.whl", hash = "sha256:e444a31f8db13eb18ada366ab3cf45fd4b31e4db1236a4448f68778c1d1a5a2f", size = 15739, upload-time = "2024-10-18T15:21:42.784Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
 ]
 
 [[package]]
 name = "mcp"
-version = "1.23.1"
+version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -652,9 +908,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/12/42/10c0c09ca27aceacd8c428956cfabdd67e3d328fe55c4abc16589285d294/mcp-1.23.1.tar.gz", hash = "sha256:7403e053e8e2283b1e6ae631423cb54736933fea70b32422152e6064556cd298", size = 596519, upload-time = "2025-12-02T18:41:12.807Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/9e/26e1d2d2c6afe15dfba5ca6799eeeea7656dce625c22766e4c57305e9cc2/mcp-1.23.1-py3-none-any.whl", hash = "sha256:3ce897fcc20a41bd50b4c58d3aa88085f11f505dcc0eaed48930012d34c731d8", size = 231433, upload-time = "2025-12-02T18:41:11.195Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [[package]]
@@ -676,35 +932,6 @@ wheels = [
 ]
 
 [[package]]
-name = "nest-asyncio"
-version = "1.6.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418, upload-time = "2024-01-21T14:25:19.227Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195, upload-time = "2024-01-21T14:25:17.223Z" },
-]
-
-[[package]]
-name = "openapi-core"
-version = "0.19.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "isodate" },
-    { name = "jsonschema" },
-    { name = "jsonschema-path" },
-    { name = "more-itertools" },
-    { name = "openapi-schema-validator" },
-    { name = "openapi-spec-validator" },
-    { name = "parse" },
-    { name = "typing-extensions" },
-    { name = "werkzeug" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/35/1acaa5f2fcc6e54eded34a2ec74b479439c4e469fc4e8d0e803fda0234db/openapi_core-0.19.5.tar.gz", hash = "sha256:421e753da56c391704454e66afe4803a290108590ac8fa6f4a4487f4ec11f2d3", size = 103264, upload-time = "2025-03-20T20:17:28.193Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/6f/83ead0e2e30a90445ee4fc0135f43741aebc30cca5b43f20968b603e30b6/openapi_core-0.19.5-py3-none-any.whl", hash = "sha256:ef7210e83a59394f46ce282639d8d26ad6fc8094aa904c9c16eb1bac8908911f", size = 106595, upload-time = "2025-03-20T20:17:26.77Z" },
-]
-
-[[package]]
 name = "openapi-pydantic"
 version = "0.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -717,32 +944,15 @@ wheels = [
 ]
 
 [[package]]
-name = "openapi-schema-validator"
-version = "0.6.3"
+name = "opentelemetry-api"
+version = "1.44.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jsonschema" },
-    { name = "jsonschema-specifications" },
-    { name = "rfc3339-validator" },
+    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/f3/5507ad3325169347cd8ced61c232ff3df70e2b250c49f0fe140edb4973c6/openapi_schema_validator-0.6.3.tar.gz", hash = "sha256:f37bace4fc2a5d96692f4f8b31dc0f8d7400fd04f3a937798eaf880d425de6ee", size = 11550, upload-time = "2025-01-10T18:08:22.268Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/21/c6/ad0fba32775ae749016829dace42ed80f4407b171da41313d1a3a5f102e4/openapi_schema_validator-0.6.3-py3-none-any.whl", hash = "sha256:f3b9870f4e556b5a62a1c39da72a6b4b16f3ad9c73dc80084b1b11e74ba148a3", size = 8755, upload-time = "2025-01-10T18:08:19.758Z" },
-]
-
-[[package]]
-name = "openapi-spec-validator"
-version = "0.7.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "jsonschema" },
-    { name = "jsonschema-path" },
-    { name = "lazy-object-proxy" },
-    { name = "openapi-schema-validator" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/82/af/fe2d7618d6eae6fb3a82766a44ed87cd8d6d82b4564ed1c7cfb0f6378e91/openapi_spec_validator-0.7.2.tar.gz", hash = "sha256:cc029309b5c5dbc7859df0372d55e9d1ff43e96d678b9ba087f7c56fc586f734", size = 36855, upload-time = "2025-06-07T14:48:56.299Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/dd/b3fd642260cb17532f66cc1e8250f3507d1e580483e209dc1e9d13bd980d/openapi_spec_validator-0.7.2-py3-none-any.whl", hash = "sha256:4bbdc0894ec85f1d1bea1d6d9c8b2c3c8d7ccaa13577ef40da9c006c9fd0eb60", size = 39713, upload-time = "2025-06-07T14:48:54.077Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
 ]
 
 [[package]]
@@ -755,15 +965,6 @@ wheels = [
 ]
 
 [[package]]
-name = "parse"
-version = "1.20.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4f/78/d9b09ba24bb36ef8b83b71be547e118d46214735b6dfb39e4bfde0e9b9dd/parse-1.20.2.tar.gz", hash = "sha256:b41d604d16503c79d81af5165155c0b20f6c8d6c559efa66b4b695c3e5a0a0ce", size = 29391, upload-time = "2024-06-11T04:41:57.34Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/31/ba45bf0b2aa7898d81cbbfac0e88c267befb59ad91a19e36e1bc5578ddb1/parse-1.20.2-py2.py3-none-any.whl", hash = "sha256:967095588cb802add9177d0c0b6133b5ba33b1ea9007ca800e526f42a85af558", size = 20126, upload-time = "2024-06-11T04:41:55.057Z" },
-]
-
-[[package]]
 name = "pathable"
 version = "0.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -773,12 +974,80 @@ wheels = [
 ]
 
 [[package]]
+name = "pathvalidate"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/2a/52a8da6fe965dea6192eb716b357558e103aea0a1e9a8352ad575a8406ca/pathvalidate-3.3.1.tar.gz", hash = "sha256:b18c07212bfead624345bb8e1d6141cdcf15a39736994ea0b94035ad2b1ba177", size = 63262, upload-time = "2025-06-15T09:07:20.736Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/70/875f4a23bfc4731703a5835487d0d2fb999031bd415e7d17c0ae615c18b7/pathvalidate-3.3.1-py3-none-any.whl", hash = "sha256:5263baab691f8e1af96092fa5137ee17df5bdfbd6cff1fcac4d6ef4bc2e1735f", size = 24305, upload-time = "2025-06-15T09:07:19.117Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
+]
+
+[[package]]
+name = "py-key-value-aio"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beartype" },
+    { name = "py-key-value-shared" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/93/ce/3136b771dddf5ac905cc193b461eb67967cf3979688c6696e1f2cdcde7ea/py_key_value_aio-0.3.0.tar.gz", hash = "sha256:858e852fcf6d696d231266da66042d3355a7f9871650415feef9fca7a6cd4155", size = 50801, upload-time = "2025-11-17T16:50:04.711Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/10/72f6f213b8f0bce36eff21fda0a13271834e9eeff7f9609b01afdc253c79/py_key_value_aio-0.3.0-py3-none-any.whl", hash = "sha256:1c781915766078bfd608daa769fefb97e65d1d73746a3dfb640460e322071b64", size = 96342, upload-time = "2025-11-17T16:50:03.801Z" },
+]
+
+[package.optional-dependencies]
+disk = [
+    { name = "diskcache" },
+    { name = "pathvalidate" },
+]
+keyring = [
+    { name = "keyring" },
+]
+memory = [
+    { name = "cachetools" },
+]
+redis = [
+    { name = "redis" },
+]
+
+[[package]]
+name = "py-key-value-shared"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beartype" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7b/e4/1971dfc4620a3a15b4579fe99e024f5edd6e0967a71154771a059daff4db/py_key_value_shared-0.3.0.tar.gz", hash = "sha256:8fdd786cf96c3e900102945f92aa1473138ebe960ef49da1c833790160c28a4b", size = 11666, upload-time = "2025-11-17T16:50:06.849Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/e4/b8b0a03ece72f47dce2307d36e1c34725b7223d209fc679315ffe6a4e2c3/py_key_value_shared-0.3.0-py3-none-any.whl", hash = "sha256:5b0efba7ebca08bb158b1e93afc2f07d30b8f40c2fc12ce24a4c0d84f42f9298", size = 19560, upload-time = "2025-11-17T16:50:05.954Z" },
 ]
 
 [[package]]
@@ -878,6 +1147,30 @@ wheels = [
 ]
 
 [[package]]
+name = "pydocket"
+version = "0.23.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "burner-redis" },
+    { name = "cloudpickle" },
+    { name = "cronsim" },
+    { name = "opentelemetry-api" },
+    { name = "prometheus-client" },
+    { name = "py-key-value-aio", extra = ["memory", "redis"] },
+    { name = "python-json-logger" },
+    { name = "redis" },
+    { name = "rich" },
+    { name = "typer" },
+    { name = "typing-extensions" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+    { name = "uncalled-for" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e7/f6/3018cfe7a30c5dc844421336a5bb07c7547e8aee83e3e34ef04ea461fcb5/pydocket-0.23.0.tar.gz", hash = "sha256:831c7df7b72e2135307c37441618946d413674bb026e29219b892244f72c8d5f", size = 424266, upload-time = "2026-07-03T13:25:53.764Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/83/354f75660f583469df61b9553680552240774a991c33fbd77aded9a95a8a/pydocket-0.23.0-py3-none-any.whl", hash = "sha256:ab2b9de8d892a814db432e473b8a7a4340c43ed32852b142d2f3d053a6156075", size = 128604, upload-time = "2026-07-03T13:25:52.358Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -902,11 +1195,11 @@ crypto = [
 
 [[package]]
 name = "pyodide-py"
-version = "0.28.3"
+version = "0.29.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2d/59/95d573e0d967af70d8823552c1efee19eb2dfbca23de9ca139516c98c5d1/pyodide_py-0.28.3.tar.gz", hash = "sha256:e521d9714eb57b163e0aadca40b85870a8ea949cb03443c0e5f3ed7d45cd3a98", size = 52898, upload-time = "2025-09-22T15:17:45.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/e2/35e934789449ef1d1534a2a195d0fa7795c857a24499e0dbbf557af74a83/pyodide_py-0.29.3.tar.gz", hash = "sha256:d553d60d95ba8ed3a368f2d1448c4283a3d752511f25d86b3cadfc79a58e4a07", size = 58740, upload-time = "2026-01-28T09:26:08.727Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/2a/2cca0a4e52a9495f21cab634b58dc413fddf72faf5baed9d2c8741544631/pyodide_py-0.28.3-py3-none-any.whl", hash = "sha256:de6ba9db35ed1ef75b80a70cf11dafa373ad786f95f72e9dbe46ffaf8cdea23c", size = 58853, upload-time = "2025-09-22T15:17:44.104Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/1a/9b312385c634a8ec3210be6790e3cf2593af5490675c5e27c4f908001da8/pyodide_py-0.29.3-py3-none-any.whl", hash = "sha256:0108040da4f072058e751c4ad35182cd54803c73258024c2b93012d199c18315", size = 66015, upload-time = "2026-01-28T09:26:07.392Z" },
 ]
 
 [[package]]
@@ -920,7 +1213,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "8.4.1"
+version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -929,27 +1222,36 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/08/ba/45911d754e8eba3d5a841a5ce61a65a685ff1798421ac054f85aa8747dfb/pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c", size = 1517714, upload-time = "2025-06-18T05:48:06.109Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/29/16/c8a903f4c4dffe7a12843191437d7cd8e32751d5de349d45d3fe69544e87/pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7", size = 365474, upload-time = "2025-06-18T05:48:03.955Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
 ]
 
 [[package]]
 name = "python-dotenv"
-version = "1.1.1"
+version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f6/b0/4bc07ccd3572a2f9df7e6782f52b0c6c90dcbb803ac4a167702d7d0dfe1e/python_dotenv-1.1.1.tar.gz", hash = "sha256:a8a6399716257f45be6a007360200409fce5cda2661e3dec71d23dc15f6189ab", size = 41978, upload-time = "2025-06-24T04:21:07.341Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6", size = 44221, upload-time = "2025-10-26T15:12:10.434Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/ed/539768cf28c661b5b068d66d96a2f155c4971a5d55684a514c1a0e0dec2f/python_dotenv-1.1.1-py3-none-any.whl", hash = "sha256:31f23644fe2602f88ff55e1f5c79ba497e01224ee7737937930c448e4d0e24dc", size = 20556, upload-time = "2025-06-24T04:21:06.073Z" },
+    { url = "https://files.pythonhosted.org/packages/14/1b/a298b06749107c305e1fe0f814c6c74aea7b2f1e10989cb30f544a1b3253/python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61", size = 21230, upload-time = "2025-10-26T15:12:09.109Z" },
+]
+
+[[package]]
+name = "python-json-logger"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/ff/3cc9165fd44106973cd7ac9facb674a65ed853494592541d339bdc9a30eb/python_json_logger-4.1.0.tar.gz", hash = "sha256:b396b9e3ed782b09ff9d6e4f1683d46c83ad0d35d2e407c09a9ebbf038f88195", size = 17573, upload-time = "2026-03-29T04:39:56.805Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/be/0631a861af4d1c875f096c07d34e9a63639560a717130e7a87cbc82b7e3f/python_json_logger-4.1.0-py3-none-any.whl", hash = "sha256:132994765cf75bf44554be9aa49b06ef2345d23661a96720262716438141b6b2", size = 15021, upload-time = "2026-03-29T04:39:55.266Z" },
 ]
 
 [[package]]
 name = "python-multipart"
-version = "0.0.20"
+version = "0.0.22"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/87/f44d7c9f274c7ee665a29b885ec97089ec5dc034c7f3fafa03da9e39a09e/python_multipart-0.0.20.tar.gz", hash = "sha256:8dd0cab45b8e23064ae09147625994d090fa46f5b0d1e13af944c331a7fa9d13", size = 37158, upload-time = "2024-12-16T19:45:46.972Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/58/38b5afbc1a800eeea951b9285d3912613f2603bdf897a4ab0f4bd7f405fc/python_multipart-0.0.20-py3-none-any.whl", hash = "sha256:8a62d3a8335e06589fe01f2a3e178cdcc632f3fbe0d492ad9ee0ec35aab1f104", size = 24546, upload-time = "2024-12-16T19:45:44.423Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
 ]
 
 [[package]]
@@ -968,18 +1270,19 @@ wheels = [
 
 [[package]]
 name = "pytincture"
-version = "0.9.22"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
     { name = "aioredis" },
+    { name = "argon2-cffi" },
     { name = "authlib" },
+    { name = "bcrypt" },
     { name = "fastapi" },
     { name = "fastmcp" },
     { name = "itsdangerous" },
     { name = "js" },
     { name = "markupsafe" },
-    { name = "nest-asyncio" },
     { name = "pyodide-py" },
     { name = "pytest" },
     { name = "python-dotenv" },
@@ -995,25 +1298,26 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiofiles", specifier = "==24.1.0" },
+    { name = "aiofiles", specifier = "==25.1.0" },
     { name = "aioredis", specifier = "==2.0.1" },
-    { name = "authlib", specifier = "==1.6.5" },
-    { name = "fastapi", specifier = "==0.119.0" },
-    { name = "fastmcp", specifier = "==2.12.4" },
+    { name = "argon2-cffi", specifier = "==25.1.0" },
+    { name = "authlib", specifier = "==1.6.6" },
+    { name = "bcrypt", specifier = "==5.0.0" },
+    { name = "fastapi", specifier = "==0.128.0" },
+    { name = "fastmcp", specifier = "==2.14.5" },
     { name = "itsdangerous", specifier = "==2.2.0" },
     { name = "js", specifier = "==1.0" },
-    { name = "markupsafe", specifier = "==3.0.2" },
-    { name = "nest-asyncio", specifier = "==1.6.0" },
-    { name = "pyodide-py", specifier = "==0.28.3" },
-    { name = "pytest", specifier = "==8.4.1" },
-    { name = "python-dotenv", specifier = "==1.1.1" },
-    { name = "python-multipart", specifier = "==0.0.20" },
+    { name = "markupsafe", specifier = "==3.0.3" },
+    { name = "pyodide-py", specifier = "==0.29.3" },
+    { name = "pytest", specifier = "==9.0.2" },
+    { name = "python-dotenv", specifier = "==1.2.1" },
+    { name = "python-multipart", specifier = "==0.0.22" },
     { name = "python3-saml", specifier = "==1.16.0" },
     { name = "pyyaml", specifier = "==6.0.3" },
     { name = "requests", specifier = "==2.32.5" },
     { name = "upstash-redis", specifier = ">=1.2.0" },
-    { name = "uvicorn", specifier = "==0.37.0" },
-    { name = "wheel", specifier = "==0.45.1" },
+    { name = "uvicorn", specifier = "==0.40.0" },
+    { name = "wheel", specifier = "==0.46.3" },
     { name = "xmlsec", specifier = ">=1.3.17" },
 ]
 
@@ -1028,6 +1332,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
     { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
     { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
+]
+
+[[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
 ]
 
 [[package]]
@@ -1067,6 +1380,15 @@ wheels = [
 ]
 
 [[package]]
+name = "redis"
+version = "8.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/c3/928b290c2c0ca99ab96eea5b4ff8f30be8112b075301a7d3ba214a3c8c12/redis-8.0.1.tar.gz", hash = "sha256:afc5a7a2f5a084f5b1880dec548dd45be17db7e43c82a30d84f952aefb05cfb0", size = 5114170, upload-time = "2026-06-23T14:52:37.728Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/0a/c2345ebf1ebe70840ce3f6c6ee612f8fa749cfbd1b03069c53bf0c62aaad/redis-8.0.1-py3-none-any.whl", hash = "sha256:47daa35a058c23468d6437f17a8c76882cb316b838ef763036af99b96cedd743", size = 502406, upload-time = "2026-06-23T14:52:36.137Z" },
+]
+
+[[package]]
 name = "referencing"
 version = "0.36.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1092,18 +1414,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
-]
-
-[[package]]
-name = "rfc3339-validator"
-version = "0.1.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/28/ea/a9387748e2d111c3c2b275ba970b735e04e15cdb1eb30693b6b5708c4dbd/rfc3339_validator-0.1.4.tar.gz", hash = "sha256:138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b", size = 5513, upload-time = "2021-05-12T16:37:54.178Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/44/4e421b96b67b2daff264473f7465db72fbdf36a07e05494f50300cc7b0c6/rfc3339_validator-0.1.4-py2.py3-none-any.whl", hash = "sha256:24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa", size = 3490, upload-time = "2021-05-12T16:37:52.536Z" },
 ]
 
 [[package]]
@@ -1199,6 +1509,19 @@ wheels = [
 ]
 
 [[package]]
+name = "secretstorage"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "jeepney" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
+]
+
+[[package]]
 name = "setuptools"
 version = "80.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1208,12 +1531,12 @@ wheels = [
 ]
 
 [[package]]
-name = "six"
-version = "1.17.0"
+name = "shellingham"
+version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
 ]
 
 [[package]]
@@ -1241,6 +1564,21 @@ wheels = [
 ]
 
 [[package]]
+name = "typer"
+version = "0.27.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/37/78/fda3361b56efc27944f24225f6ecd13d96d6fcfe37bd0eb34e2f4c63f9fc/typer-0.27.0.tar.gz", hash = "sha256:629bd12ea5d13a17148125d9a264f949eb171fb3f120f9b04d85873cab054fa5", size = 203430, upload-time = "2026-07-15T19:21:07.007Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/03/26a383c9e58c213199d1aad1c3d353cfc22d4444ec6d2c0bf8ad02523843/typer-0.27.0-py3-none-any.whl", hash = "sha256:6f4b27631e47f077871b7dc30e933ec0131c1390fbe0e387ea5574b5bac9ccf1", size = 122716, upload-time = "2026-07-15T19:21:05.553Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1259,6 +1597,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
+]
+
+[[package]]
+name = "uncalled-for"
+version = "0.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/82/345cc927f7fbdae6065e7768759932fcc827fc20b29b45dfbafa2f1f7da4/uncalled_for-0.3.2.tar.gz", hash = "sha256:89f5dbcd71e2b8f47c030b1fa302e6cce2ec795d1ac565eeb6525c5fe55cb8a2", size = 50032, upload-time = "2026-05-06T13:38:25.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/25/2c87754f3a9e692315f7b811244090e68f362979fc8886b3fbd2985a1d8c/uncalled_for-0.3.2-py3-none-any.whl", hash = "sha256:0ff60b142c7d1f8070bde9d42afaa70aedc77dcc10998c227687e9c15713418e", size = 11444, upload-time = "2026-05-06T13:38:24.025Z" },
 ]
 
 [[package]]
@@ -1284,15 +1640,15 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-version = "0.37.0"
+version = "0.40.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/71/57/1616c8274c3442d802621abf5deb230771c7a0fec9414cb6763900eb3868/uvicorn-0.37.0.tar.gz", hash = "sha256:4115c8add6d3fd536c8ee77f0e14a7fd2ebba939fed9b02583a97f80648f9e13", size = 80367, upload-time = "2025-09-23T13:33:47.486Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/d1/8f3c683c9561a4e6689dd3b1d345c815f10f86acd044ee1fb9a4dcd0b8c5/uvicorn-0.40.0.tar.gz", hash = "sha256:839676675e87e73694518b5574fd0f24c9d97b46bea16df7b8c05ea1a51071ea", size = 81761, upload-time = "2025-12-21T14:16:22.45Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/cd/584a2ceb5532af99dd09e50919e3615ba99aa127e9850eafe5f31ddfdb9a/uvicorn-0.37.0-py3-none-any.whl", hash = "sha256:913b2b88672343739927ce381ff9e2ad62541f9f8289664fa1d1d3803fa2ce6c", size = 67976, upload-time = "2025-09-23T13:33:45.842Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/d8/2083a1daa7439a66f3a48589a57d576aa117726762618f6bb09fe3798796/uvicorn-0.40.0-py3-none-any.whl", hash = "sha256:c6c8f55bc8bf13eb6fa9ff87ad62308bbbc33d0b67f84293151efe87e0d5f2ee", size = 68502, upload-time = "2025-12-21T14:16:21.041Z" },
 ]
 
 [[package]]
@@ -1308,24 +1664,75 @@ wheels = [
 ]
 
 [[package]]
-name = "werkzeug"
-version = "3.1.1"
+name = "websockets"
+version = "16.1"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "markupsafe" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/32/af/d4502dc713b4ccea7175d764718d5183caf8d0867a4f0190d5d4a45cea49/werkzeug-3.1.1.tar.gz", hash = "sha256:8cd39dfbdfc1e051965f156163e2974e52c210f130810e9ad36858f0fd3edad4", size = 806453, upload-time = "2024-11-01T16:40:45.462Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/02/b9a097e1e16fee4e2fd1ec8c39f6a9c5d6257bae8fa12640caf869f54436/websockets-16.1.tar.gz", hash = "sha256:299468cbe42e2b9981134c7c51d99387d8a7bf562b00183b3eec53f882846dad", size = 182530, upload-time = "2026-07-10T06:32:57.734Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/ea/c67e1dee1ba208ed22c06d1d547ae5e293374bfc43e0eb0ef5e262b68561/werkzeug-3.1.1-py3-none-any.whl", hash = "sha256:a71124d1ef06008baafa3d266c02f56e1836a5984afd6dd6c9230669d60d9fb5", size = 224371, upload-time = "2024-11-01T16:40:43.994Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/63/df158b155420b566f025e75613424ad9649a24bcb0e9f259321ab3d58bea/websockets-16.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:b0232ed141cec3df2af5a3959a071c51f40036336b0d37e17faf9ef52fc73e47", size = 179791, upload-time = "2026-07-10T06:31:33.108Z" },
+    { url = "https://files.pythonhosted.org/packages/74/cf/00fe9414dfeafa6fe54eae9f5716c8c8e9ac59d192be3b893c096d395846/websockets-16.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a71b73d143991714144e159f767b698f03c4a70b8a65ae1733b650cff488045b", size = 177472, upload-time = "2026-07-10T06:31:34.522Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/76/b10633424d40681b4e892ffd08ca5226322b2426e62d4ab71eae484c3a32/websockets-16.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:187323204c3b2fc465e8fc2609e60437c521790cb9c1acb49c4c452a33e57f37", size = 177737, upload-time = "2026-07-10T06:31:35.964Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/61/d3bb03b2229bb1afd72008742d586cf1ea240dce64dd48c71c8c7fd3294c/websockets-16.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9dba74233c8c3ce368850818c98354dad2570f57231b3fd3bd00d7aa57628881", size = 187403, upload-time = "2026-07-10T06:31:37.496Z" },
+    { url = "https://files.pythonhosted.org/packages/26/16/cc2e80478f688fc3c39c67dc1fac6a0783858058914ebc2489917462cb42/websockets-16.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:63339bc8c63c86a463177775cb7c677691f5bcfac7b3b2f01b286d42acd41600", size = 188639, upload-time = "2026-07-10T06:31:38.86Z" },
+    { url = "https://files.pythonhosted.org/packages/15/d6/ad87b2507e57de1cbf897a56c963f2925962ed5e85fbe06aaa83ced27acd/websockets-16.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:23e545ea8ae4263e37cdfd4e22a217f519e48e432728bc461185bbf585f38a83", size = 190078, upload-time = "2026-07-10T06:31:40.218Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/1a/5b37b3fd335d5811f29fc829f2646a3e6d1463a4bf09c3100708684c766e/websockets-16.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2237081454846fb40403a80ba86d82e2038b9c45865ab96af0abe7d002a91045", size = 189267, upload-time = "2026-07-10T06:31:41.523Z" },
+    { url = "https://files.pythonhosted.org/packages/42/98/06afc33e9450d4230f94c664db78875d90f5f6a5fb77f0bc6ec15ae74e1c/websockets-16.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5f5218de1ed047385ca53744caba9435d65f75d008364970a3fae95a05812cf9", size = 188022, upload-time = "2026-07-10T06:31:42.838Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/42fef5d5887c18cf2d148b02debf56cecb9cfbffc68027cde9b12c8f432c/websockets-16.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:75c98e3920039d0edff03b74478ada504b7ce3a1bc406db2cabfca84320f7baf", size = 185435, upload-time = "2026-07-10T06:31:44.219Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/9b/8021c133add5fe40ed40312553a6cd1408c069d7efe3444ad483d4973ed3/websockets-16.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1facd189d8190af30487a55b4c3688484dd50801628a3b5b2ccd26db08e67057", size = 188080, upload-time = "2026-07-10T06:31:45.986Z" },
+    { url = "https://files.pythonhosted.org/packages/69/54/1e37384f395eaa127383aab15c1c45e200890a7d7b99db5c312233d193e0/websockets-16.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:cc0c6a6eef613c7da32d4fb068f82ef834b58134f6a16b54e6c1e5bf9529ab3d", size = 186678, upload-time = "2026-07-10T06:31:47.449Z" },
+    { url = "https://files.pythonhosted.org/packages/68/79/1caeacab5bc2081e4519288d248bc8bd2de30652e6eaa94be6be09a1fe5b/websockets-16.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:ad9411eded8988b879be6038206698bf7106c85a78f642c004485bcb95be17eb", size = 188554, upload-time = "2026-07-10T06:31:48.886Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/83/b3dca5fad71487b726e31cb0acf56f226792c1cc34e6ab18cbf146bd2d74/websockets-16.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:cd68f0914f3b64694895bc5e9b14e8b447e41d7bf5ffaf989bb8dcb5e2dfdce7", size = 186109, upload-time = "2026-07-10T06:31:50.508Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/0b/8f246c3712f07f207b52ea5fb47f3b2b66fafec7303162644c74aed51c6a/websockets-16.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:fef2debfe7f7ebdda12176f26166f95b7af17af05ba06150fcf889032e0213e9", size = 187061, upload-time = "2026-07-10T06:31:51.861Z" },
+    { url = "https://files.pythonhosted.org/packages/47/eb/27d6c92a01696b6495386af4fc941d7d0a13f2eab2bf9c336111d7321491/websockets-16.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a3cd6c9b798218798f4bb7b2e71c38f0e744bb94ca537b13376f88019d46384d", size = 187347, upload-time = "2026-07-10T06:31:53.246Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/d5/eeee439921f55d5eaeabcea18d0f7ce32cdc39cb8fc1e185431a094c5c7b/websockets-16.1-cp313-cp313-win32.whl", hash = "sha256:84c170c6869633536921e4474b1cce7254c0c9b0053ef5725f966cee47e718e4", size = 180149, upload-time = "2026-07-10T06:31:55.058Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/03/971e98d4a4864cf263f9e94c5b2b7c9a9b7682d77bfbba4e732c55ee85a9/websockets-16.1-cp313-cp313-win_amd64.whl", hash = "sha256:bef52d327d70fa75dad93ee61ea2cb1d1489aca9f35c188833563f5a3b4df0a5", size = 180458, upload-time = "2026-07-10T06:31:56.767Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/e6/da1dc11507f8118145a81c751fe0c77e5e1c11b8554496addb39389e2dc2/websockets-16.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:f881fca0a45dd6789939bd6637cd98169b92f1c3fdc78262f2cb9ec2cb1f324e", size = 179833, upload-time = "2026-07-10T06:31:58.19Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/ac/c0d46f62e31e232487b2c123bc3cfd9a4e45684ca7dc0c37f0987f29baae/websockets-16.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:30c379d5b207d3a7f0ba4c2e4602a895b0bcc63fb5f5371a4ae7fbddb03b672b", size = 177524, upload-time = "2026-07-10T06:31:59.563Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/33/abd966074b34a51e4f134e0aaed80f5a4a0a35163ea5ac58a1bc5a076d23/websockets-16.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:98ab58a4faa72b46da0127ccc1931dcbfc0985b0778892300a092185910c4cbe", size = 177743, upload-time = "2026-07-10T06:32:00.959Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/30/646e47b8a8dff04e227bdab512e6dde60663a647eeac7bbd6edddd92bbc5/websockets-16.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8e9c4e369fc181b2d41a99e01477215cecdc8546a39f7d41a59cc0a7065a0b09", size = 187474, upload-time = "2026-07-10T06:32:02.54Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/72/890ab9d77494af93ea65268230bfbc0a90ba789401ed7a44356a44785644/websockets-16.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0704df094b2d5fa7f6f410925a594c2a5c9a09167731a76292e5410934208209", size = 188717, upload-time = "2026-07-10T06:32:04.156Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/aa/baedbbaa6bf9ed6029617ed5e8976535bd805f483ca9b3484e7ad9ee08bf/websockets-16.1-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:b22b1f4950f6ab7126623329c3b47b3b90a14c05db517f2db2a026ad6c928352", size = 190090, upload-time = "2026-07-10T06:32:05.822Z" },
+    { url = "https://files.pythonhosted.org/packages/52/4f/d813ec94e18002571ef4959d87a630eff6e01b72a51bcb0832b75ae8c51a/websockets-16.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1ae4a686a662964a6671069f84f7f908cc3475e782227726b0c622c715962105", size = 189320, upload-time = "2026-07-10T06:32:07.223Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/3c/8ec52a6662f3df64090fba28cd521d405d54759268d8e820477037e8c80d/websockets-16.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:856bdd638f8277f86465057bfdd4da097c73058fb0f9d2bd5baea29e2bf2d367", size = 188068, upload-time = "2026-07-10T06:32:08.586Z" },
+    { url = "https://files.pythonhosted.org/packages/96/7f/f0ae6042b14f86fa5f996c6563ea4cf107adc036ccbedc9d4f418d0095f9/websockets-16.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9003a1fde1c21a322a3ca3fa0c4bda8c639da81dbc925162766086643b05ba87", size = 185493, upload-time = "2026-07-10T06:32:09.968Z" },
+    { url = "https://files.pythonhosted.org/packages/89/ad/5ffc53af9939c49fd653d147fa5b8f78ced1f6bce6c49a7446860945b0ce/websockets-16.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:39e947b1f5fdab045174306e3916785bf3ed537648acc1549827c08c33b10953", size = 188141, upload-time = "2026-07-10T06:32:11.434Z" },
+    { url = "https://files.pythonhosted.org/packages/67/62/729206c0ee577a4db8eae6dd06e0eef725a1287c6df11b2ef831d003df31/websockets-16.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:5dd0e666b5931c0509cf65714686a1c5126771e663a79ac5d40da4f58b1f9502", size = 186653, upload-time = "2026-07-10T06:32:12.845Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/86/e8806a99ec4589914f255e6b658853fe537bf359c05e6ba5762ad9c27917/websockets-16.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:a0285df7925657ad65a65fb8dc330808bce082827538fd50ef45fa12d1fc5bca", size = 188614, upload-time = "2026-07-10T06:32:14.236Z" },
+    { url = "https://files.pythonhosted.org/packages/89/38/ac554e2fc6ff0b8deeff9798b92e7abd8f99e2bd9731532e7033de208220/websockets-16.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:82d1c2cab3c133e9d059b3a5420bed9376bd30e21c185c63dda4ddadf6ddda47", size = 186165, upload-time = "2026-07-10T06:32:15.626Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c5/4ef4d8e53342f94f3c49e1ae089b32c1e8b3878e15e0022c7708c647f351/websockets-16.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:c39907f1eaf11f6277def65aa02d68f30576b693d0c1ca332aafa3caa723ac6d", size = 187119, upload-time = "2026-07-10T06:32:17.114Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/33/4788b1dd417bd97eeb2698af3b9df6775ac656f96e9987da0419a067602f/websockets-16.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:45c5ea55446171949eb99fd34b771ceddd511ca21958d40d0197ced33159e5ee", size = 187411, upload-time = "2026-07-10T06:32:18.629Z" },
+    { url = "https://files.pythonhosted.org/packages/30/38/00d37aad6dc3244ce349e2864815362e50b3cfc00cac28d216db20efe40f/websockets-16.1-cp314-cp314-win32.whl", hash = "sha256:b8ef8b1c8d6bd029a475ac432e730fba2dfd456715d26c473e2a82291024b99c", size = 179822, upload-time = "2026-07-10T06:32:20.233Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/37/2a8cb0eaddee5eaebda47a90a3ba0898d1ce3d866b02a4857fea17d82e5b/websockets-16.1-cp314-cp314-win_amd64.whl", hash = "sha256:7358ff21632b5d062707f73e859c824f1c3807e73d8ca25e71caca7c4cdcf145", size = 180167, upload-time = "2026-07-10T06:32:21.749Z" },
+    { url = "https://files.pythonhosted.org/packages/07/5a/262ad5fcaef4198997b165060f09a63f861e76939b1786ab546ccc3f8120/websockets-16.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:d0f38f4c3e9b359e257c339c2cc1967ccaeedb102e57c1c986bdce4bf4f32268", size = 180166, upload-time = "2026-07-10T06:32:23.278Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/c7/36377db690f4292826e4501a6dec2801dc55fd1cf0405923b04937e478df/websockets-16.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:3c3d2cbd1602593bad49bd86fa3fbb25407d87a3b4bf8857c0ac5ac4914e1901", size = 177697, upload-time = "2026-07-10T06:32:25.164Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c7/07171abce1e39799a76f473608580fe98bd43a1230f5146159622c02bccf/websockets-16.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:36069b74671e7e667f48a7484249f84c45a825a134c8b1bdc01875d0daa10d79", size = 177902, upload-time = "2026-07-10T06:32:26.564Z" },
+    { url = "https://files.pythonhosted.org/packages/14/17/c831f48e250bc4749f57c00dcce73337c41cd32f6d59a64567b84e782601/websockets-16.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:587f83c2ce8a5d628e166384d77fa7f0ac69b9007d515ab442123e6615aa8da3", size = 187766, upload-time = "2026-07-10T06:32:27.981Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/2e/4dfe63e245b0ecfaf470cf082d25c6ce35808159135fd88c82653a6b11ab/websockets-16.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a6db7972d52bc1b66cefe2246902e256cbaebc9ba8a45eac09343d7eb6671b2", size = 188939, upload-time = "2026-07-10T06:32:29.365Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/e5/5faf65aebd9562f6b4bc473d24ce38cc56f84eb5f5bee66ed9b86733f93c/websockets-16.1-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e7d6014888a0632e1ed7a4095248bb3095232999447f2d83bfb1900987dd9ed9", size = 191081, upload-time = "2026-07-10T06:32:30.868Z" },
+    { url = "https://files.pythonhosted.org/packages/49/cd/2634f2f2c0556c1aae6501ed6840019cc569dd6fdbcac6494378daea4dc0/websockets-16.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9cb074d150e4ad2a77aa8a332c2be85f3f64f2681519d2570c1225c12c9821ff", size = 189513, upload-time = "2026-07-10T06:32:32.399Z" },
+    { url = "https://files.pythonhosted.org/packages/59/bb/2c700b51196104f09715b326b1f092ed25326bdf79a03e00a4842e503743/websockets-16.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d19c9067e1fe9490f974bffbc0e443b80a7674c5efb4980c429cc00771f07c5a", size = 188240, upload-time = "2026-07-10T06:32:33.897Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/20/86283636e499a1a357fa9441f690ba34f255e731f2fea174132b3b762b57/websockets-16.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d440ff0c6c7469ad59c0a412c383c235935b43635e89425e3f6a0c36de90c31b", size = 185955, upload-time = "2026-07-10T06:32:35.279Z" },
+    { url = "https://files.pythonhosted.org/packages/91/23/d7fb734b0095d43bc7f1c9f68afd50adb4176e7e513403e8c70ad7daa4fa/websockets-16.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8613129a2533f08de24505e69a3e403cedaadae49abdb043c4d170ca71b7e4bd", size = 188491, upload-time = "2026-07-10T06:32:36.673Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/5e/168a192689db468405ecf3b8e4a2c18811936b0724d017ad7e6d252734f0/websockets-16.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:a5bf9c23f197b4ec88290fd5463f33db67362a1bb10f85fc2e8e7627f0ddab97", size = 186983, upload-time = "2026-07-10T06:32:38.207Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/9b/66795fa91ebe49019ebe4fa910282172252e37046b80e08fc52e0c365150/websockets-16.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:520b0fd0395f075febb283c76755af724ab9fd19dffa4f3bfd18cb4e622790a3", size = 188890, upload-time = "2026-07-10T06:32:39.545Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/32/126bbc844be5afb3613fd43211dac10a9645f4cf39741d04acaa2ec7030c/websockets-16.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:7143aa09a67e1c013be44e81a88dfe90fc6244198ab86c7edd064152cf619805", size = 186583, upload-time = "2026-07-10T06:32:41.038Z" },
+    { url = "https://files.pythonhosted.org/packages/22/b9/0b5db9cbcf6e4970db4496893244a8d92e07f71a8ef27cf34b08aa02fef1/websockets-16.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:7acb811fad08e611755800d1560e395c67e11a6bd563598ea6abb319afb86938", size = 187353, upload-time = "2026-07-10T06:32:42.501Z" },
+    { url = "https://files.pythonhosted.org/packages/99/2e/254b2131a10d831b76e2c18dfe7add9729c6292c674a8085bf8de01ad151/websockets-16.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c5cf88e3faa2f7931bc6baeee7599c97656a3f6ac7f831f4fccba233e141783a", size = 187784, upload-time = "2026-07-10T06:32:43.929Z" },
+    { url = "https://files.pythonhosted.org/packages/21/dc/e7288aa8e3ac5a88a0924619984d663c1abf2a87d0ea98290c66fdaee0ec/websockets-16.1-cp314-cp314t-win32.whl", hash = "sha256:589f8842521c8307684ce0b40ce4ad70c5e0aa46484c6f1225a94ef4b8970341", size = 179947, upload-time = "2026-07-10T06:32:45.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/de/37edf1260ff0fbbd2f82433489c4cfbe799ac2ff21355331609879329fe6/websockets-16.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c0e0857c30bbbc2bb5c30687508f0b7ec19aa026cd9f2ff8424d0fee42dcc07", size = 180291, upload-time = "2026-07-10T06:32:47.119Z" },
+    { url = "https://files.pythonhosted.org/packages/66/58/bd83247f39ddc26ffc2c24eb05087a3b749e00cb4509fc6d19daa23c8495/websockets-16.1-py3-none-any.whl", hash = "sha256:c5149dfe490ec7e5ee5dbf624c642fb725f93a5575c7f00ab594ca9eddb8dd81", size = 174031, upload-time = "2026-07-10T06:32:56.079Z" },
 ]
 
 [[package]]
 name = "wheel"
-version = "0.45.1"
+version = "0.46.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8a/98/2d9906746cdc6a6ef809ae6338005b3f21bb568bea3165cfc6a243fdc25c/wheel-0.45.1.tar.gz", hash = "sha256:661e1abd9198507b1409a20c02106d9670b2576e916d58f520316666abca6729", size = 107545, upload-time = "2024-11-23T00:18:23.513Z" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/89/24/a2eb353a6edac9a0303977c4cb048134959dd2a51b48a269dfc9dde00c8a/wheel-0.46.3.tar.gz", hash = "sha256:e3e79874b07d776c40bd6033f8ddf76a7dad46a7b8aa1b2787a83083519a1803", size = 60605, upload-time = "2026-01-22T12:39:49.136Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/2c/87f3254fd8ffd29e4c02732eee68a83a1d3c346ae39bc6822dcbcb697f2b/wheel-0.45.1-py3-none-any.whl", hash = "sha256:708e7481cc80179af0e556bbf0cc00b8444c7321e2700b8d8580231d13017248", size = 72494, upload-time = "2024-11-23T00:18:21.207Z" },
+    { url = "https://files.pythonhosted.org/packages/87/22/b76d483683216dde3d67cba61fb2444be8d5be289bf628c13fc0fd90e5f9/wheel-0.46.3-py3-none-any.whl", hash = "sha256:4b399d56c9d9338230118d705d9737a2a468ccca63d5e813e2a4fc7815d8bc4d", size = 30557, upload-time = "2026-01-22T12:39:48.099Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Release pytincture 0.10.0 with a comprehensive security hardening pass across authentication, sessions, BFF execution, browser packaging, MCP exposure, and error handling.

## What changed

- Require strong production session secrets and support signing-key rotation and session revocation.
- Add Argon2id/bcrypt local-password verification and an explicit loopback-only development email-login flag.
- Add CSRF and origin validation for authenticated state-changing requests.
- Replace dynamic BFF discovery with a static exported-operation registry, explicit HTTP-method declarations, pre-import policy checks, execution limits, and bounded streams.
- Add an opt-in one-time BFF request-proof pool. Generated browser stubs automatically refill an opaque token pool and reject copied/replayed completed requests.
- Make replay refill capsules stateless across backend restarts when the persistent session secret is stable; use Upstash for cross-replica one-time-token consumption when configured.
- Export no MCP tools by default and reject sensitive operation exports.
- Restrict public application assets and browser archives so Python source, configuration, server helpers, and development files are not exposed accidentally.
- Sanitize validation, OAuth, SAML, and internal error responses while adding correlation IDs.
- Add request-body, execution-time, stream-time, and stream-size limits. Rate limiting remains intentionally delegated to the deployment gateway.
- Tighten wheel contents, refresh locked dependencies, update frontend tooling, and bump all package versions to 0.10.0.

## Compatibility and migration

This release intentionally includes compatibility changes:

- BFF methods default to POST; read-only GET methods must use `@bff_http_methods("GET")`.
- Authenticated unsafe requests require the CSRF token header. Generated browser stubs handle this automatically.
- Production authentication requires a stable, strong `SAML_SECRET_KEY` or legacy `SECRET_KEY`.
- Passwordless `ALLOWED_EMAILS` login requires `ENABLE_DEV_EMAIL_LOGIN=true` and a loopback request.
- MCP and additional browser-packaged/public files require explicit allowlists.
- The replay-obscurity layer is opt-in with `ENABLE_BFF_REPLAY_TOKENS=true` and is documented as a replay barrier, not a browser-side security boundary.

The README contains the environment-variable reference and migration guidance.

## Validation

- `uv run pytest -q` — 87 passed
- `npm run build` — passed
- `npm audit --audit-level=moderate` — 0 vulnerabilities
- `uv build --no-build-logs` — sdist and wheel built successfully
- Wheel-content verification — 24 intended files; no tests, caches, build trees, or `node_modules`
- `python -m compileall` and `git diff --check` — passed
