### PR TITLE
Release 0.10.2 with restored local user profile claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ pip install .
 - ENABLE_USER_LOGIN: Enable verified local email/password login. This route is rejected when the flag is false.
 - AUTH_PASSWORD_HASHES: JSON object mapping normalized email addresses to Argon2id or bcrypt hashes.
    example: `{"user@example.com":"$argon2id$..."}`
+- AUTH_USER_CLAIMS: Optional JSON user list or email-to-claims object used to hydrate verified local users with application profile fields. Password and token fields are always discarded. When unset, `DEFAULT_APP_USERS` is read as a compatibility fallback after password verification succeeds.
+- AUTH_SESSION_CLAIM_KEYS: Optional comma-separated names of additional trusted claims to retain in the signed session. `id`, `role`, `plan`, `next_billing`, `theme`, and `sidebar` are retained by default; passwords, hashes, secrets, and tokens are never retained.
 - AUTH_USER_AUTHENTICATOR: Optional dotted path to a sync or async callable accepting `email`, `password`, and `request`. It must return trusted user claims, `True`, or `False`.
 - ENABLE_DEV_EMAIL_LOGIN: Allow a non-empty `ALLOWED_EMAILS` list without password verification only on loopback hosts. This is intentionally unsafe and must only be set to `true` for local development.
 - ENABLE_GOOGLE_AUTH: Enable the respective authentication mechanisms.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "pytincture"
 
-version = "0.10.1"
+version = "0.10.2"
 
 description = "UI Builder"
 readme = "README.md"

--- a/pytincture/__init__.py
+++ b/pytincture/__init__.py
@@ -2,7 +2,7 @@
 pyTincture uvicorn launcher
 """
 
-__version__ = "0.10.1"
+__version__ = "0.10.2"
 
 from multiprocessing import Process, freeze_support
 import os

--- a/pytincture/backend/app.py
+++ b/pytincture/backend/app.py
@@ -965,6 +965,63 @@ def _verify_configured_password(email: str, password: str) -> bool:
     raise RuntimeError("AUTH_PASSWORD_HASHES values must be Argon2id or bcrypt hashes")
 
 
+_SENSITIVE_USER_CLAIM_KEYS = {
+    "password",
+    "password_hash",
+    "secret",
+    "token",
+    "access_token",
+    "refresh_token",
+    "id_token",
+}
+
+
+def _configured_local_user_claims(email: str) -> Dict[str, Any]:
+    """Load profile claims separately from password verification.
+
+    AUTH_USER_CLAIMS is the preferred source. DEFAULT_APP_USERS remains a
+    compatibility fallback, but any password or token fields are discarded.
+    """
+    raw_claims = os.getenv("AUTH_USER_CLAIMS", "").strip()
+    source_name = "AUTH_USER_CLAIMS"
+    if not raw_claims:
+        raw_claims = os.getenv("DEFAULT_APP_USERS", "").strip()
+        source_name = "DEFAULT_APP_USERS"
+    if not raw_claims:
+        return {"email": email}
+    try:
+        configured = json.loads(raw_claims)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"{source_name} must contain valid JSON") from exc
+
+    matched: Optional[Dict[str, Any]] = None
+    if isinstance(configured, list):
+        for candidate in configured:
+            if (
+                isinstance(candidate, dict)
+                and str(candidate.get("email") or "").strip().casefold() == email
+            ):
+                matched = candidate
+                break
+    elif isinstance(configured, dict):
+        for configured_email, candidate in configured.items():
+            if str(configured_email).strip().casefold() == email and isinstance(candidate, dict):
+                matched = candidate
+                break
+    else:
+        raise RuntimeError(f"{source_name} must be a user list or email-to-claims object")
+
+    if matched is None:
+        return {"email": email}
+    claims = {
+        str(key): value
+        for key, value in matched.items()
+        if str(key).casefold() not in _SENSITIVE_USER_CLAIM_KEYS
+    }
+    claims["email"] = email
+    return claims
+
+
 async def _authenticate_local_user(
     request: Request, email: str, password: str
 ) -> Dict[str, Any]:
@@ -990,7 +1047,7 @@ async def _authenticate_local_user(
         return {**authenticated, "email": normalized_email}
 
     if _verify_configured_password(normalized_email, password):
-        return {"email": normalized_email}
+        return _configured_local_user_claims(normalized_email)
 
     if (
         ENABLE_DEV_EMAIL_LOGIN
@@ -998,7 +1055,7 @@ async def _authenticate_local_user(
         and _is_loopback_development_request(request)
     ):
         logger.warning("Using loopback-only development email login for %s", normalized_email)
-        return {"email": normalized_email}
+        return _configured_local_user_claims(normalized_email)
 
     raise HTTPException(status_code=401, detail="Invalid email or password")
 
@@ -1099,6 +1156,33 @@ def _normalize_auth_roles(value: Any) -> List[str]:
     return sorted(roles)
 
 
+_DEFAULT_AUTH_SESSION_CLAIM_KEYS = {
+    "id",
+    "role",
+    "plan",
+    "next_billing",
+    "theme",
+    "sidebar",
+}
+
+
+def _auth_session_claim_keys() -> Set[str]:
+    configured = {
+        key.strip()
+        for key in os.getenv("AUTH_SESSION_CLAIM_KEYS", "").split(",")
+        if key.strip() and key.strip().casefold() not in _SENSITIVE_USER_CLAIM_KEYS
+    }
+    return _DEFAULT_AUTH_SESSION_CLAIM_KEYS | configured
+
+
+def _safe_session_claim_value(value: Any) -> bool:
+    try:
+        encoded = json.dumps(value, separators=(",", ":"))
+    except (TypeError, ValueError):
+        return False
+    return len(encoded.encode("utf-8")) <= 1024
+
+
 def _build_auth_session_user(
     user_info: Any,
     *,
@@ -1128,9 +1212,27 @@ def _build_auth_session_user(
         "name": str(source.get("name") or "").strip(),
         "picture": str(source.get("picture") or "appcode/profile.png"),
         "auth_type": resolved_auth_type,
-        "roles": _normalize_auth_roles(source.get("roles")),
+        "roles": _normalize_auth_roles(source.get("roles", source.get("role"))),
         "is_authenticated": True,
     }
+    reserved_claims = set(session_user) | {
+        "password",
+        "password_hash",
+        "secret",
+        "token",
+        "access_token",
+        "refresh_token",
+        "id_token",
+        "saml",
+    }
+    for claim_name in sorted(_auth_session_claim_keys()):
+        if (
+            claim_name not in reserved_claims
+            and claim_name.casefold() not in _SENSITIVE_USER_CLAIM_KEYS
+            and claim_name in source
+            and _safe_session_claim_value(source[claim_name])
+        ):
+            session_user[claim_name] = source[claim_name]
     if resolved_provider:
         session_user["auth_provider"] = resolved_provider
     if resolved_provider_label:
@@ -3032,7 +3134,7 @@ async def auth_user_callback(request: Request, application: str):
         **authenticated_claims,
         "picture": f"{application}/appcode/profile.png",
         "auth_type": "user",
-        "roles": authenticated_claims.get("roles", []),
+        "roles": authenticated_claims.get("roles", authenticated_claims.get("role", [])),
     }
 
     _set_authenticated_user(request, user_info)
@@ -3058,12 +3160,12 @@ async def mcp_auth(request: Request, application: str, auth_input: MCPAuthInput 
         **authenticated_claims,
         "picture": f"{application}/appcode/profile.png",
         "auth_type": "user",
-        "roles": authenticated_claims.get("roles", []),
+        "roles": authenticated_claims.get("roles", authenticated_claims.get("role", [])),
     }
 
-    _set_authenticated_user(request, user_info)
+    session_user = _set_authenticated_user(request, user_info)
 
-    return {"status": "authenticated"}
+    return {**session_user, "status": "authenticated"}
 
 # ======================
 # The /{application} route

--- a/pytincture/frontend/package.json
+++ b/pytincture/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pytincture/runtime",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Standalone pytincture.js runtime with inline app auto-start support.",
   "type": "module",
   "main": "dist/pytincture.js",

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -65,6 +65,9 @@ def override_env(monkeypatch):
     monkeypatch.setenv("USE_REDIS_INSTANCE", "false")
     monkeypatch.setenv("ALLOWED_NOAUTH_CLASSCALLS", json.dumps([]))
     monkeypatch.delenv("PYTINCTURE_DEFAULT_APPLICATION", raising=False)
+    monkeypatch.delenv("AUTH_USER_CLAIMS", raising=False)
+    monkeypatch.delenv("AUTH_SESSION_CLAIM_KEYS", raising=False)
+    monkeypatch.delenv("DEFAULT_APP_USERS", raising=False)
 
     # Import the module and override its globals.
     import pytincture.backend.app as backend_app
@@ -152,6 +155,65 @@ def test_password_hash_verifier_rejects_wrong_password(fresh_client, monkeypatch
         follow_redirects=False,
     )
     assert correct.status_code == 303
+
+
+def test_password_login_hydrates_safe_default_app_user_claims(
+    fresh_client, monkeypatch
+):
+    import pytincture.backend.app as backend_app
+    from argon2 import PasswordHasher
+
+    monkeypatch.setattr(backend_app, "ENABLE_GOOGLE_AUTH", False)
+    monkeypatch.setattr(backend_app, "ENABLE_USER_LOGIN", True)
+    monkeypatch.setattr(backend_app, "ENABLE_DEV_EMAIL_LOGIN", False)
+    monkeypatch.setenv("ALLOWED_EMAILS", "admin@arul.ai")
+    monkeypatch.setenv(
+        "AUTH_PASSWORD_HASHES",
+        json.dumps({"admin@arul.ai": PasswordHasher().hash("admin")}),
+    )
+    monkeypatch.setenv(
+        "DEFAULT_APP_USERS",
+        json.dumps([{
+            "id": "1",
+            "name": "Admin",
+            "email": "ADMIN@ARUL.AI",
+            "role": "Viewer",
+            "password": "must-not-return",
+            "access_token": "must-not-return",
+            "plan": "Enterprise",
+            "next_billing": "Dec 15, 2023",
+            "theme": "Dark",
+            "sidebar": "Open",
+        }]),
+    )
+
+    response = fresh_client.post(
+        "/demoapp/auth/mcp",
+        json={"email": "admin@arul.ai", "password": "admin"},
+    )
+
+    assert response.status_code == 200
+    returned_user = response.json()
+    assert returned_user["status"] == "authenticated"
+    assert returned_user["id"] == "1"
+    assert returned_user["name"] == "Admin"
+    assert returned_user["role"] == "Viewer"
+    assert returned_user["roles"] == ["viewer"]
+    assert returned_user["plan"] == "Enterprise"
+    assert returned_user["next_billing"] == "Dec 15, 2023"
+    assert returned_user["theme"] == "Dark"
+    assert returned_user["sidebar"] == "Open"
+    assert "password" not in returned_user
+    assert "access_token" not in returned_user
+
+    session_user = _decode_session_cookie(
+        fresh_client,
+        backend_app.SAML_SECRET_KEY,
+    )["user"]
+    assert session_user["id"] == "1"
+    assert session_user["role"] == "Viewer"
+    assert "password" not in session_user
+    assert "access_token" not in session_user
 
 
 def test_development_email_login_is_loopback_only(monkeypatch):

--- a/uv.lock
+++ b/uv.lock
@@ -1213,7 +1213,7 @@ wheels = [
 
 [[package]]
 name = "pytincture"
-version = "0.10.1"
+version = "0.10.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

Release 0.10.2 with restored application profile claims for hash-verified local users, without trusting or returning plaintext passwords.

## Root cause

Pytincture 0.10 verifies local credentials through `AUTH_PASSWORD_HASHES`, but successful hash authentication returned only the normalized email. The compact session builder also discarded application fields such as `id`, `role`, `plan`, and UI preferences. Applications whose login flow expected `user["id"]` therefore failed with `KeyError: 'id'` even though authentication succeeded.

## Changes

- Hydrate a successfully verified local user from `AUTH_USER_CLAIMS`.
- Read `DEFAULT_APP_USERS` as a compatibility fallback when explicit auth claims are not configured.
- Keep password verification exclusively in `AUTH_PASSWORD_HASHES` or the configured authenticator.
- Always discard password, password-hash, secret, and token fields from claims.
- Preserve `id`, `role`, `plan`, `next_billing`, `theme`, and `sidebar` in signed sessions by default.
- Support additional explicitly configured fields through `AUTH_SESSION_CLAIM_KEYS`.
- Normalize a singular `role` into the authorization `roles` list while retaining the original application-facing field.
- Return the safe session claims from JSON login alongside `status="authenticated"`.
- Bump both the Python distribution and JavaScript runtime to 0.10.2.

## Validation

- Reproduced the reported `user["id"]` contract with `admin@arul.ai` profile data.
- Verified Argon2id password authentication hydrates the expected profile.
- Verified plaintext password and access-token fields are absent from both the response and signed session.
- `uv run pytest -q` — 90 passed.
- `uv build --no-build-logs` — built and verified the 0.10.2 wheel with 24 intended files.
